### PR TITLE
[Feat] JwtAuthenticationFilter 생성 및 FilterChain에 등록 (#22)

### DIFF
--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,22 @@
+package com.ada.earthvalley.yomojomo.auth;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return false;
+    }
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/configs/SecurityConfig.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/configs/SecurityConfig.java
@@ -1,14 +1,27 @@
 package com.ada.earthvalley.yomojomo.configs;
 
+import com.ada.earthvalley.yomojomo.auth.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
+@RequiredArgsConstructor
 @Configuration
 public class SecurityConfig {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .addFilterAt(
+                        jwtAuthenticationFilter,
+                        BasicAuthenticationFilter.class)
+                .authorizeRequests()
+                .anyRequest().authenticated()
+        ;
         return http.build();
     }
 }


### PR DESCRIPTION
## 작업 개요
<!-- ex) 고양이가 야옹 소리를 내도록 수정 -->
JwtAuthenticationFilter 생성 및 FilterChain에 등록

## 이슈 티켓
<!-- ex) 작업한 이슈를 태그하세요. -->
#22 

## 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ] 설정


## 작업 상세 내용
<!--  ex) 1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴 -->  3. 


## 특이사항 
<!-- 1. wav 파일을 매번 입력하기 귀찮겠다. -->
Filter 등록의 경우 테스트코드 작성이 어려워 생략했습니다.
다만 FilterChainProxy를 이용해 등록된 filter를 로깅하여 해당 필터가 등록되었음을 확인했습니다.


