### PR TITLE
[Feat] Exception Handler 및 ErrorResponse 정의 (#28)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
+	testCompileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/ada/earthvalley/yomojomo/common/exceptions/ErrorCode.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/common/exceptions/ErrorCode.java
@@ -1,0 +1,16 @@
+package com.ada.earthvalley.yomojomo.common.exceptions;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    ;
+    private final int code;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/common/exceptions/ErrorCode.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/common/exceptions/ErrorCode.java
@@ -1,9 +1,9 @@
 package com.ada.earthvalley.yomojomo.common.exceptions;
 
 
+import org.springframework.http.HttpStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/ada/earthvalley/yomojomo/common/exceptions/ErrorInfo.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/common/exceptions/ErrorInfo.java
@@ -1,0 +1,10 @@
+package com.ada.earthvalley.yomojomo.common.exceptions;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorInfo {
+    String getMessage();
+    int getCode();
+
+    HttpStatus getStatus();
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/common/exceptions/ErrorResponse.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/common/exceptions/ErrorResponse.java
@@ -1,10 +1,10 @@
 package com.ada.earthvalley.yomojomo.common.exceptions;
 
-import lombok.Getter;
+import java.time.LocalDateTime;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import lombok.Getter;
 
-import java.time.LocalDateTime;
 
 @Getter
 public class ErrorResponse {

--- a/src/main/java/com/ada/earthvalley/yomojomo/common/exceptions/ErrorResponse.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/common/exceptions/ErrorResponse.java
@@ -1,0 +1,31 @@
+package com.ada.earthvalley.yomojomo.common.exceptions;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ErrorResponse {
+    private final LocalDateTime timestamp = LocalDateTime.now();
+    private String status;
+    private int code;
+    private String message;
+    // TODO: BindException 을 위한 FieldError 정의 (by Leo 22.10.31)
+
+
+    public static ResponseEntity<ErrorResponse> createResponseEntity(ErrorInfo info) {
+        return ResponseEntity.status(info.getStatus()).body(new ErrorResponse(info));
+    }
+
+    private ErrorResponse(ErrorInfo info) {
+        this.status = stateToString(info.getStatus());
+        this.code = info.getCode();
+        this.message = info.getMessage();
+    }
+
+    private String stateToString(HttpStatus status) {
+        return status.value() + " " + status.getReasonPhrase().toUpperCase();
+    }
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/common/exceptions/YomojomoException.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/common/exceptions/YomojomoException.java
@@ -1,0 +1,20 @@
+package com.ada.earthvalley.yomojomo.common.exceptions;
+
+import lombok.Getter;
+
+@Getter
+public class YomojomoException extends RuntimeException {
+    private ErrorInfo info;
+
+    private YomojomoException() {
+    }
+
+    protected YomojomoException(ErrorInfo info) {
+        super(info.getMessage());
+        this.info = info;
+    }
+
+    public static YomojomoException of(ErrorInfo code) {
+        return new YomojomoException(code);
+    }
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/common/exceptions/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/common/exceptions/handler/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.ada.earthvalley.yomojomo.common.exceptions.handler;
+
+import com.ada.earthvalley.yomojomo.common.exceptions.ErrorResponse;
+import com.ada.earthvalley.yomojomo.common.exceptions.YomojomoException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(YomojomoException.class)
+    protected ResponseEntity<ErrorResponse> handleYomojomoException(YomojomoException e) {
+        log.error("Yomojomo Custom Exception: {}", e.getMessage());
+        return ErrorResponse.createResponseEntity(e.getInfo());
+    }
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/common/exceptions/ExceptionTestController.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/common/exceptions/ExceptionTestController.java
@@ -1,9 +1,10 @@
 package com.ada.earthvalley.yomojomo.common.exceptions;
 
-import com.ada.earthvalley.yomojomo.common.exceptions.errors.YomojomoTestException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.ada.earthvalley.yomojomo.common.exceptions.errors.YomojomoTestException;
 
 @RestController
 public class ExceptionTestController {

--- a/src/test/java/com/ada/earthvalley/yomojomo/common/exceptions/ExceptionTestController.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/common/exceptions/ExceptionTestController.java
@@ -1,0 +1,17 @@
+package com.ada.earthvalley.yomojomo.common.exceptions;
+
+import com.ada.earthvalley.yomojomo.common.exceptions.errors.YomojomoTestException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ExceptionTestController {
+    @Autowired
+    public ErrorInfo errorInfo;
+
+    @GetMapping("/throws")
+    void throwException() {
+        throw YomojomoTestException.of(errorInfo);
+    }
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/common/exceptions/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/common/exceptions/GlobalExceptionHandlerTest.java
@@ -1,6 +1,10 @@
 package com.ada.earthvalley.yomojomo.common.exceptions;
 
-import com.ada.earthvalley.yomojomo.common.exceptions.handler.GlobalExceptionHandler;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,10 +17,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.ada.earthvalley.yomojomo.common.exceptions.handler.GlobalExceptionHandler;
 
 @WebMvcTest
 class GlobalExceptionHandlerTest {

--- a/src/test/java/com/ada/earthvalley/yomojomo/common/exceptions/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/common/exceptions/GlobalExceptionHandlerTest.java
@@ -1,0 +1,61 @@
+package com.ada.earthvalley.yomojomo.common.exceptions;
+
+import com.ada.earthvalley.yomojomo.common.exceptions.handler.GlobalExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest
+class GlobalExceptionHandlerTest {
+    private MockMvc mockMvc;
+    @MockBean
+    private ErrorInfo errorInfo;
+    @Autowired
+    ExceptionTestController controller;
+
+    @BeforeEach
+    void initEach() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler.class)
+                .build()
+        ;
+    }
+
+    @DisplayName("exception handler - 성공")
+    @Test
+    void exception_handler() throws Exception {
+        final int code = 999;
+        final int status = 400;
+        final String message = "테스트 에러 메시지 입니다.";
+        when(errorInfo.getCode()).thenReturn(code);
+        when(errorInfo.getMessage()).thenReturn(message);
+        when(errorInfo.getStatus()).thenReturn(HttpStatus.BAD_REQUEST);
+
+        ResultActions perform = mockMvc.perform(
+                MockMvcRequestBuilders
+                        .get("/throws")
+        );
+
+        perform
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message", message).exists())
+                .andExpect(jsonPath("$.status", status).exists())
+                .andExpect(jsonPath("$.code", code).exists())
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/common/exceptions/errors/TestError.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/common/exceptions/errors/TestError.java
@@ -1,9 +1,9 @@
 package com.ada.earthvalley.yomojomo.common.exceptions.errors;
 
+import org.springframework.http.HttpStatus;
 import com.ada.earthvalley.yomojomo.common.exceptions.ErrorCode;
 import com.ada.earthvalley.yomojomo.common.exceptions.ErrorInfo;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum TestError implements ErrorInfo {

--- a/src/test/java/com/ada/earthvalley/yomojomo/common/exceptions/errors/TestError.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/common/exceptions/errors/TestError.java
@@ -1,0 +1,28 @@
+package com.ada.earthvalley.yomojomo.common.exceptions.errors;
+
+import com.ada.earthvalley.yomojomo.common.exceptions.ErrorCode;
+import com.ada.earthvalley.yomojomo.common.exceptions.ErrorInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum TestError implements ErrorInfo {
+    ;
+
+    private final ErrorCode code;
+
+    @Override
+    public String getMessage() {
+        return code.getMessage();
+    }
+
+    @Override
+    public int getCode() {
+        return code.getCode();
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return code.getStatus();
+    }
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/common/exceptions/errors/YomojomoTestException.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/common/exceptions/errors/YomojomoTestException.java
@@ -1,0 +1,8 @@
+package com.ada.earthvalley.yomojomo.common.exceptions.errors;
+
+import com.ada.earthvalley.yomojomo.common.exceptions.ErrorInfo;
+import com.ada.earthvalley.yomojomo.common.exceptions.YomojomoException;
+
+public class YomojomoTestException extends YomojomoException {
+    private YomojomoTestException(ErrorInfo info) { super(info); }
+}


### PR DESCRIPTION
## 작업 개요
<!-- ex) 고양이가 야옹 소리를 내도록 수정 -->
Exception Handler 및 ErrorResponse 정의

## 이슈 티켓
<!-- ex) 작업한 이슈를 태그하세요. -->
#28 

## 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [x] 테스트 코드 작성
- [x] 설정


## 작업 상세 내용
<!--  ex) 1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴 --> 
**main**
- ExceptionHandler 역할을 하는 GlobalExceptionHandler 정의
- ErrorResponse 정의
- 애플리케이션 로직 안에서 던지는 Exception 의 부모가 되는 YomojomoException 정의
- 내부 에러코드가 담긴 ErrorCode 정의
- 각 domain 별로 정의할 error enum의 interface인 ErrorInfo 정의

**test**
- 테스트에 수반되는 테스트 클래스들 정의 (TestError, YomojomoTestException, ExceptionTestController)

## 생각해볼 문제
<!-- 1. wav 파일을 매번 입력하기 귀찮겠다. -->
ErrorCode를 어디서 어떻게 관리할지 좀 더 고민해봐야겠다. 


