### PR TITLE
[Feat] ERD -> JPA 엔티티 매핑 

### DIFF
--- a/src/main/java/com/ada/earthvalley/yomojomo/YomojomoApplication.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/YomojomoApplication.java
@@ -2,7 +2,9 @@ package com.ada.earthvalley.yomojomo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class YomojomoApplication {
 

--- a/src/main/java/com/ada/earthvalley/yomojomo/article/entities/Topic.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/article/entities/Topic.java
@@ -1,0 +1,29 @@
+package com.ada.earthvalley.yomojomo.article.entities;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import com.ada.earthvalley.yomojomo.common.baseEntities.BaseEntity;
+import com.ada.earthvalley.yomojomo.article.entities.enums.TopicType;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Topic extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	@Column(name = "topic_id")
+	private long id;
+
+	@Enumerated(EnumType.STRING)
+	private TopicType type;
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/article/entities/enums/TopicType.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/article/entities/enums/TopicType.java
@@ -1,0 +1,4 @@
+package com.ada.earthvalley.yomojomo.article.entities.enums;
+
+public enum TopicType {
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/configs/SecurityConfig.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/configs/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.ada.earthvalley.yomojomo.configs;
+package com.ada.earthvalley.yomojomo.auth.configs;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/RefreshToken.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/RefreshToken.java
@@ -1,0 +1,18 @@
+package com.ada.earthvalley.yomojomo.auth.entities;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Embeddable;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class RefreshToken {
+	private String refreshToken;
+	private LocalDateTime expiredAt;
+	private LocalDateTime issuedAt = LocalDateTime.now();
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/RefreshToken.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/RefreshToken.java
@@ -2,7 +2,11 @@ package com.ada.earthvalley.yomojomo.auth.entities;
 
 import java.time.LocalDateTime;
 
-import javax.persistence.Embeddable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -10,9 +14,16 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Embeddable
+@Entity
 public class RefreshToken {
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	@Column(name = "token_id")
+	private long id;
+
 	private String refreshToken;
+
 	private LocalDateTime expiredAt;
+
 	private LocalDateTime issuedAt = LocalDateTime.now();
 }

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/VendorResource.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/VendorResource.java
@@ -1,0 +1,39 @@
+package com.ada.earthvalley.yomojomo.auth.entities;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import com.ada.earthvalley.yomojomo.common.baseEntities.BaseEntity;
+import com.ada.earthvalley.yomojomo.auth.entities.enums.VendorType;
+import com.ada.earthvalley.yomojomo.user.entities.User;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class VendorResource extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	@Column(name = "vendor_resource_id")
+	private long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	private String vendorId;
+
+	@Enumerated(EnumType.STRING)
+	private VendorType type;
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/enums/VendorType.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/enums/VendorType.java
@@ -1,0 +1,5 @@
+package com.ada.earthvalley.yomojomo.auth.entities.enums;
+
+public enum VendorType {
+	KAKAO, APPLE;
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/common/baseEntities/BaseEntity.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/common/baseEntities/BaseEntity.java
@@ -1,0 +1,26 @@
+package com.ada.earthvalley.yomojomo.common.baseEntities;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.Getter;
+
+@Getter
+@EntityListeners({AuditingEntityListener.class})
+@MappedSuperclass
+public abstract class BaseEntity {
+	@CreatedDate
+	@Column(updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/group/entities/Group.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/group/entities/Group.java
@@ -1,0 +1,44 @@
+package com.ada.earthvalley.yomojomo.group.entities;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+
+import com.ada.earthvalley.yomojomo.common.baseEntities.BaseEntity;
+import com.ada.earthvalley.yomojomo.group.entities.enums.GroupType;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Group extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	@Column(name = "group_id")
+	private long id;
+
+	private String title;
+
+	// TODO: Group 이 삭제되었을 때 NIE 와 긴밀한 관계가 있는 GroupUser 는 어떻게 되야할까.
+	@OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<GroupUser> groupUsers = new ArrayList<>();
+
+	@Enumerated(EnumType.STRING)
+	private GroupType type;
+
+	@OneToOne(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
+	private Invitation invitation;
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/group/entities/Group.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/group/entities/Group.java
@@ -13,6 +13,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
+import javax.persistence.Table;
 
 import com.ada.earthvalley.yomojomo.common.baseEntities.BaseEntity;
 import com.ada.earthvalley.yomojomo.group.entities.enums.GroupType;
@@ -24,6 +25,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Table(name = "groups")
 public class Group extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/java/com/ada/earthvalley/yomojomo/group/entities/GroupUser.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/group/entities/GroupUser.java
@@ -1,0 +1,44 @@
+package com.ada.earthvalley.yomojomo.group.entities;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+
+import com.ada.earthvalley.yomojomo.common.baseEntities.BaseEntity;
+import com.ada.earthvalley.yomojomo.nie.entities.Nie;
+import com.ada.earthvalley.yomojomo.user.entities.User;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class GroupUser extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	@Column(name = "group_user_id")
+	private long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "group_id")
+	private Group group;
+
+	@OneToMany(mappedBy = "groupUser", cascade = CascadeType.PERSIST)
+	private List<Nie> nies = new ArrayList<>();
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/group/entities/Invitation.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/group/entities/Invitation.java
@@ -1,0 +1,35 @@
+package com.ada.earthvalley.yomojomo.group.entities;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+
+import com.ada.earthvalley.yomojomo.common.baseEntities.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Invitation extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	@Column(name = "invitation_id")
+	private long id;
+
+	@OneToOne
+	@JoinColumn(name = "group_id", nullable = false)
+	private Group group;
+
+	private String code;
+
+	private LocalDateTime expiredAt;
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/group/entities/enums/GroupType.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/group/entities/enums/GroupType.java
@@ -1,0 +1,5 @@
+package com.ada.earthvalley.yomojomo.group.entities.enums;
+
+public enum GroupType {
+	SOLITARY, CLASSROOM
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/Nie.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/Nie.java
@@ -1,0 +1,54 @@
+package com.ada.earthvalley.yomojomo.nie.entities;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+
+import com.ada.earthvalley.yomojomo.common.baseEntities.BaseEntity;
+import com.ada.earthvalley.yomojomo.group.entities.GroupUser;
+import com.ada.earthvalley.yomojomo.nie.entities.enums.NieStatus;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// TODO: GroupUser 가 orphan 이 되어서 삭제된다면 NIE 는 어떻게 되는게 맞는가 ?
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Nie extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	@Column(name = "nie_id")
+	private long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "group_user_id")
+	private GroupUser groupUser;
+
+	@OneToMany(mappedBy = "nie", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<NieProcess> processes = new ArrayList<>();
+
+	@Embedded
+	@Column(updatable = false)
+	private NieContext context;
+
+	@Enumerated(EnumType.STRING)
+	private NieStatus status;
+
+	private long articleId;
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/NieContext.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/NieContext.java
@@ -1,0 +1,21 @@
+package com.ada.earthvalley.yomojomo.nie.entities;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+import com.ada.earthvalley.yomojomo.nie.entities.enums.NieProcessType;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class NieContext {
+	@Enumerated(EnumType.STRING)
+	private NieProcessType lastProcess;
+	private long articleCursor;
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/NieProcess.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/NieProcess.java
@@ -1,0 +1,38 @@
+package com.ada.earthvalley.yomojomo.nie.entities;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import com.ada.earthvalley.yomojomo.common.baseEntities.BaseEntity;
+import com.ada.earthvalley.yomojomo.nie.entities.enums.NieProcessType;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class NieProcess extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	@Column
+	private long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "nie_id")
+	private Nie nie;
+
+	@Enumerated(EnumType.STRING)
+	private NieProcessType type;
+
+	private String content;
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/enums/NieProcessType.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/enums/NieProcessType.java
@@ -1,0 +1,14 @@
+package com.ada.earthvalley.yomojomo.nie.entities.enums;
+
+public enum NieProcessType {
+	GUESSING,
+	READING,
+	WHEN,
+	WHO,
+	WHERE,
+	WHAT,
+	HOW,
+	WHY,
+	SUMMARY;
+}
+

--- a/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/enums/NieStatus.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/enums/NieStatus.java
@@ -1,0 +1,8 @@
+package com.ada.earthvalley.yomojomo.nie.entities.enums;
+
+public enum NieStatus {
+	IN_PROGRESS,
+	UPDATING,
+	FINISHED,
+	DELETED;
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/user/entities/User.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/user/entities/User.java
@@ -1,0 +1,58 @@
+package com.ada.earthvalley.yomojomo.user.entities;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+import com.ada.earthvalley.yomojomo.common.baseEntities.BaseEntity;
+import com.ada.earthvalley.yomojomo.auth.entities.RefreshToken;
+import com.ada.earthvalley.yomojomo.group.entities.GroupUser;
+import com.ada.earthvalley.yomojomo.user.entities.enums.UserRole;
+import com.ada.earthvalley.yomojomo.word.entities.Word;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+@Entity
+public class User extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	@Column(name = "user_id")
+	private UUID id;
+
+	private String username;
+
+	private String nickname;
+
+	private String phone;
+
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Word> words = new ArrayList<>();
+
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<UserTopic> userTopics = new ArrayList<>();
+
+	@OneToMany(mappedBy = "user")
+	private List<GroupUser> groupUsers = new ArrayList<>();
+
+	@Enumerated(EnumType.STRING)
+	private UserRole role;
+
+	@Embedded
+	@Column(updatable = false)
+	private RefreshToken refreshToken;
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/user/entities/User.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/user/entities/User.java
@@ -26,7 +26,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PUBLIC)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class User extends BaseEntity {
 	@Id

--- a/src/main/java/com/ada/earthvalley/yomojomo/user/entities/User.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/user/entities/User.java
@@ -6,13 +6,14 @@ import java.util.UUID;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
-import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
@@ -55,7 +56,7 @@ public class User extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private UserRole role;
 
-	@Embedded
-	@Column(updatable = false)
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+	@JoinColumn(name = "token_id")
 	private RefreshToken refreshToken;
 }

--- a/src/main/java/com/ada/earthvalley/yomojomo/user/entities/User.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/user/entities/User.java
@@ -14,6 +14,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
 
 import com.ada.earthvalley.yomojomo.common.baseEntities.BaseEntity;
 import com.ada.earthvalley.yomojomo.auth.entities.RefreshToken;
@@ -28,6 +30,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Table(name = "users")
 public class User extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/java/com/ada/earthvalley/yomojomo/user/entities/UserTopic.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/user/entities/UserTopic.java
@@ -1,0 +1,35 @@
+package com.ada.earthvalley.yomojomo.user.entities;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import com.ada.earthvalley.yomojomo.common.baseEntities.BaseEntity;
+import com.ada.earthvalley.yomojomo.article.entities.Topic;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class UserTopic extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	@Column(name = "user_topic_id")
+	private long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "topic_id")
+	private Topic topic;
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/user/entities/enums/UserRole.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/user/entities/enums/UserRole.java
@@ -1,0 +1,8 @@
+package com.ada.earthvalley.yomojomo.user.entities.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum UserRole {
+	ADMIN, INSTRUCTOR, STUDENT
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/word/entities/Word.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/word/entities/Word.java
@@ -1,0 +1,33 @@
+package com.ada.earthvalley.yomojomo.word.entities;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import com.ada.earthvalley.yomojomo.common.baseEntities.BaseEntity;
+import com.ada.earthvalley.yomojomo.user.entities.User;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Word extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	@Column(name = "word_id")
+	private long id;
+
+	private String word;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/word/entities/WordContext.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/word/entities/WordContext.java
@@ -1,0 +1,34 @@
+package com.ada.earthvalley.yomojomo.word.entities;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import com.ada.earthvalley.yomojomo.common.baseEntities.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class WordContext extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	@Column(name = "word_context_id")
+	private long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "word_id")
+	private Word word;
+
+	private long article_id;
+	private long location;
+	private String meaning;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,4 +32,3 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        globally_quoted_identifiers: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,3 +32,4 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        globally_quoted_identifiers: true

--- a/src/test/java/com/ada/earthvalley/yomojomo/group/entities/GroupsEntityTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/group/entities/GroupsEntityTest.java
@@ -1,0 +1,13 @@
+package com.ada.earthvalley.yomojomo.group.entities;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+// TODO: test scan 범위 entity 단위로 narrow down (by Leo - 22.11.02)
+@DataJpaTest
+class GroupsEntityTest {
+
+	@Test
+	void group_did_load() {
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -31,5 +31,4 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        globally_quoted_identifiers: true
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,35 @@
+spring:
+  profiles:
+    active: test, h2-test-for-postgresql
+
+---
+# H2 IN MEMORY TEST PROFILE
+spring:
+  config:
+    active.on-profile: h2-test-for-postgresql
+
+  datasource:
+    url: jdbc:h2:mem:test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH
+    username: sa
+
+  jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+
+---
+# TEST DEFAULTS
+spring:
+  config:
+    active.on-profile: test
+
+  jpa:
+    generate-ddl: true
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        globally_quoted_identifiers: true
+


### PR DESCRIPTION
## 작업 개요
<!-- ex) 고양이가 야옹 소리를 내도록 수정 -->
ERD -> JPA 엔티티 매핑 

## 이슈 티켓
<!-- ex) 작업한 이슈를 태그하세요. -->
#38 


## 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [x] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [x] 설정


## 작업 상세 내용
<!--  ex) 1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴 -->
- ERD를 JPA에 매핑했습니다.
- application.yml을 수정했습니다.
  - main path에 spring.jpa.properties.hibernate.globally_quoted_identifiers = true 추가
    - 예약어 충돌 회피를 위함.
    - test path 에 h2 embedded 설정 (PostgreSQL compatibility)
- SecurityConfig의 디렉토리를 이동했습니다.
- Entity에 대해서 각자 테스트를 진행하고 싶었지만 test scope을 entity 단위로 줄이는 방법은 시도해봤는데 잘 안되네요...
  - 일단 @DataJpaTest로 모든 entity에 대해 생성되었는지 일괄적으로 확인했습니다.


## 생각해볼 문제
<!-- 1. wav 파일을 매번 입력하기 귀찮겠다. -->
GroupUser 가 orphan 이 되어서 삭제된다면 NIE 는 어떻게 되어야 할까? 
Group 이 삭제되었을 때 NIE 와 긴밀한 관계가 있는 GroupUser 는 어떻게 되야할까
Test scope을 entity 단위로 좁히는 방법은 뭐가 있을까


