### PR TITLE
[Feat] Entity의 id 컬럼 타입을 wrapper 클래스인 Long 으로 변경

### DIFF
--- a/src/main/java/com/ada/earthvalley/yomojomo/YomojomoApplication.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/YomojomoApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class YomojomoApplication {
 

--- a/src/main/java/com/ada/earthvalley/yomojomo/article/entities/Topic.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/article/entities/Topic.java
@@ -22,7 +22,7 @@ public class Topic extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "topic_id")
-	private long id;
+	private Long id;
 
 	@Enumerated(EnumType.STRING)
 	private TopicType type;

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/RefreshToken.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/RefreshToken.java
@@ -19,7 +19,7 @@ public class RefreshToken {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "token_id")
-	private long id;
+	private Long id;
 
 	private String refreshToken;
 

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/VendorResource.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/VendorResource.java
@@ -26,7 +26,7 @@ public class VendorResource extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "vendor_resource_id")
-	private long id;
+	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")

--- a/src/main/java/com/ada/earthvalley/yomojomo/common/configs/JpaAuditingConfig.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/common/configs/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.ada.earthvalley.yomojomo.common.configs;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/group/entities/Group.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/group/entities/Group.java
@@ -30,7 +30,7 @@ public class Group extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "group_id")
-	private long id;
+	private Long id;
 
 	private String title;
 

--- a/src/main/java/com/ada/earthvalley/yomojomo/group/entities/GroupUser.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/group/entities/GroupUser.java
@@ -29,7 +29,7 @@ public class GroupUser extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "group_user_id")
-	private long id;
+	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")

--- a/src/main/java/com/ada/earthvalley/yomojomo/group/entities/Invitation.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/group/entities/Invitation.java
@@ -23,7 +23,7 @@ public class Invitation extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "invitation_id")
-	private long id;
+	private Long id;
 
 	@OneToOne
 	@JoinColumn(name = "group_id", nullable = false)

--- a/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/Nie.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/Nie.java
@@ -34,7 +34,7 @@ public class Nie extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "nie_id")
-	private long id;
+	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "group_user_id")

--- a/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/NieProcess.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/NieProcess.java
@@ -25,7 +25,7 @@ public class NieProcess extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column
-	private long id;
+	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "nie_id")

--- a/src/main/java/com/ada/earthvalley/yomojomo/user/entities/User.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/user/entities/User.java
@@ -35,7 +35,7 @@ import lombok.NoArgsConstructor;
 public class User extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
-	@Column(name = "user_id")
+	@Column(name = "user_id", columnDefinition = "uuid")
 	private UUID id;
 
 	private String username;

--- a/src/main/java/com/ada/earthvalley/yomojomo/user/entities/UserTopic.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/user/entities/UserTopic.java
@@ -23,7 +23,7 @@ public class UserTopic extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "user_topic_id")
-	private long id;
+	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")

--- a/src/main/java/com/ada/earthvalley/yomojomo/word/entities/Word.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/word/entities/Word.java
@@ -23,7 +23,7 @@ public class Word extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "word_id")
-	private long id;
+	private Long id;
 
 	private String word;
 

--- a/src/main/java/com/ada/earthvalley/yomojomo/word/entities/WordContext.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/word/entities/WordContext.java
@@ -22,7 +22,7 @@ public class WordContext extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "word_context_id")
-	private long id;
+	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "word_id")

--- a/src/test/java/com/ada/earthvalley/yomojomo/common/baseEntities/BaseEntityTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/common/baseEntities/BaseEntityTest.java
@@ -1,0 +1,47 @@
+package com.ada.earthvalley.yomojomo.common.baseEntities;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ada.earthvalley.yomojomo.word.entities.Word;
+
+@Transactional
+@SpringBootTest
+public class BaseEntityTest {
+	@PersistenceContext
+	private EntityManager em;
+
+	@DisplayName("BaseEntity - 성공")
+	@Test
+	void baseentity_success() throws
+		NoSuchMethodException,
+		InvocationTargetException,
+		InstantiationException,
+		IllegalAccessException {
+		// given
+		Constructor<Word> constructor = Word.class.getDeclaredConstructor();
+		constructor.setAccessible(true);
+		Word word = constructor.newInstance();
+
+		// when
+		em.persist(word);
+		em.flush();
+		em.clear();
+		Word findWord = em.find(Word.class, word.getId());
+
+		// then
+		assertThat(findWord).isNotNull();
+		assertThat(findWord.getCreatedAt()).isNotNull();
+		assertThat(findWord.getUpdatedAt()).isNotNull();
+	}
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/user/entities/UserTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/user/entities/UserTest.java
@@ -1,0 +1,41 @@
+package com.ada.earthvalley.yomojomo.user.entities;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+public class UserTest {
+	@PersistenceContext
+	private EntityManager em;
+
+	@DisplayName("User find - 성공")
+	@Test
+	void user_find_success() throws
+		NoSuchMethodException,
+		InvocationTargetException,
+		InstantiationException,
+		IllegalAccessException {
+		// given
+		Constructor<User> constructor = User.class.getDeclaredConstructor();
+		constructor.setAccessible(true);
+		User user = constructor.newInstance();
+
+		// when
+		em.persist(user);
+		em.flush();
+		em.clear();
+		User findUser = em.find(User.class, user.getId());
+
+		// then
+		assertThat(findUser).isNotNull();
+	}
+}


### PR DESCRIPTION
## 작업 개요
<!-- ex) 고양이가 야옹 소리를 내도록 수정 -->
Entity의 id 컬럼 타입을 wrapper 클래스인 Long 으로 변경 ... 만 하려 했으나 여러가지 trouble shooting 과정을 겪었다. 

## 이슈 티켓
<!-- ex) 작업한 이슈를 태그하세요. -->
- #42 

## 작업 분류
- [ ] 버그 수정
- [ ] 신규 기능
- [x] 프로젝트 구조 변경
- [x] 테스트 코드 작성
- [x] 설정


## 작업 상세 내용
<!--  ex) 1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴 -->
`@EnableJpaAuditing` 을 별도의 설정 클래스로 분리 
- 자세한 내용은 trouble shooting log [EnableJpaAuditing를 분리하게된 과정](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-EarthValley80-Server/wiki/EnableJpaAuditing를-분리하게된-과정)확인

User 엔티티에 대해 H2 DB 에 대한 DDL 생성 시 UUID 타입으로 매핑할 수 있도록 하기 위해 columnDefinition을 uuid로 재정의함
- 자세한 내용은 trouble shooting log [UUID 타입에 대한 에러. 저장은 하지만 조회를 못한다.](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-EarthValley80-Server/wiki/UUID-타입에-대한-에러...-저장은-하지만-조회를-못한다.) 확인

엔티티 클래스의 id 컬럼의 타입을 wrapper 클래스인 Long으로 변경 


## 생각해볼 문제
<!-- 1. wav 파일을 매번 입력하기 귀찮겠다. -->
User 엔티티의 경우 test 만을 위해 prod 코드의 변경이 일어났는데, 이를 완전히 분리할 순 없을까? 아쉽다.


