### PR TITLE
[Feat] 단일 NIE 조회 API 구현 및 테스트 + 기타 수정사항 

### DIFF
--- a/src/main/java/com/ada/earthvalley/yomojomo/YomojomoApplication.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/YomojomoApplication.java
@@ -2,7 +2,6 @@ package com.ada.earthvalley.yomojomo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 public class YomojomoApplication {

--- a/src/main/java/com/ada/earthvalley/yomojomo/YomojomoApplication.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/YomojomoApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class YomojomoApplication {
 

--- a/src/main/java/com/ada/earthvalley/yomojomo/article/entities/Topic.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/article/entities/Topic.java
@@ -22,7 +22,7 @@ public class Topic extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "topic_id")
-	private long id;
+	private Long id;
 
 	@Enumerated(EnumType.STRING)
 	private TopicType type;

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/JwtAuthenticationFilter.java
@@ -24,7 +24,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
 		JwtAuthenticationToken convert = converter.convert(request);
-
+		filterChain.doFilter(request, response);
 	}
 
 	@Override

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/configs/EnableFilterDebuggingConfig.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/configs/EnableFilterDebuggingConfig.java
@@ -1,0 +1,11 @@
+package com.ada.earthvalley.yomojomo.auth.configs;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+
+@Profile("filters-registered")
+@EnableWebSecurity(debug = true)
+@Configuration
+public class EnableFilterDebuggingConfig {
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/configs/SecurityConfig.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/configs/SecurityConfig.java
@@ -17,12 +17,15 @@ public class SecurityConfig {
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		// http
+		// 	.addFilterAt(
+		// 		jwtAuthenticationFilter,
+		// 		BasicAuthenticationFilter.class)
+		// 	.authorizeRequests()
+		// 	.anyRequest().authenticated();
 		http
-			.addFilterAt(
-				jwtAuthenticationFilter,
-				BasicAuthenticationFilter.class)
 			.authorizeRequests()
-			.anyRequest().authenticated();
+			.anyRequest().permitAll();
 		return http.build();
 	}
 }

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/RefreshToken.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/RefreshToken.java
@@ -19,7 +19,7 @@ public class RefreshToken {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "token_id")
-	private long id;
+	private Long id;
 
 	private String refreshToken;
 

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/VendorResource.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/VendorResource.java
@@ -26,7 +26,7 @@ public class VendorResource extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "vendor_resource_id")
-	private long id;
+	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")

--- a/src/main/java/com/ada/earthvalley/yomojomo/common/configs/JpaAuditingConfig.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/common/configs/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.ada.earthvalley.yomojomo.common.configs;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/common/exceptions/ErrorCode.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/common/exceptions/ErrorCode.java
@@ -9,7 +9,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
-	;
+	ERR1000(1000, HttpStatus.NOT_FOUND, "NIE가 존재하지 않습니다.");
+
 	private final int code;
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/ada/earthvalley/yomojomo/group/entities/Group.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/group/entities/Group.java
@@ -30,7 +30,7 @@ public class Group extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "group_id")
-	private long id;
+	private Long id;
 
 	private String title;
 

--- a/src/main/java/com/ada/earthvalley/yomojomo/group/entities/GroupUser.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/group/entities/GroupUser.java
@@ -29,7 +29,7 @@ public class GroupUser extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "group_user_id")
-	private long id;
+	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")

--- a/src/main/java/com/ada/earthvalley/yomojomo/group/entities/Invitation.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/group/entities/Invitation.java
@@ -23,7 +23,7 @@ public class Invitation extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "invitation_id")
-	private long id;
+	private Long id;
 
 	@OneToOne
 	@JoinColumn(name = "group_id", nullable = false)

--- a/src/main/java/com/ada/earthvalley/yomojomo/nie/controllers/NieControllerV1.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/nie/controllers/NieControllerV1.java
@@ -1,0 +1,30 @@
+package com.ada.earthvalley.yomojomo.nie.controllers;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ada.earthvalley.yomojomo.nie.services.NieFetchServiceV1;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+@RestController
+public class NieControllerV1 {
+	private final NieFetchServiceV1 nieFetchService;
+
+	@GetMapping("/nies/{nieId}")
+	public ResponseEntity fetch(
+		@PathVariable final Long nieId
+	) {
+		return ResponseEntity.ok(nieFetchService.fetchNie(nieId));
+	}
+
+	@GetMapping("/leo")
+	public String ab() {
+		return "으앙";
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/nie/dtos/FetchNieResponse.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/nie/dtos/FetchNieResponse.java
@@ -1,0 +1,58 @@
+package com.ada.earthvalley.yomojomo.nie.dtos;
+
+import com.ada.earthvalley.yomojomo.nie.entities.Nie;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FetchNieResponse {
+	private String predict;
+	private String where;
+	private String why;
+	private String what;
+	private String when;
+	private String who;
+	private String how;
+	private String summary;
+
+	// TODO: Assembler 로 리팩터링 (by Leo - 22.11.07)
+	public static FetchNieResponse of(Nie nie) {
+		FetchNieResponse response = new FetchNieResponse();
+
+		nie.getProcesses().stream().forEach(pc -> {
+			switch (pc.getType()) {
+				case HOW:
+					response.how = pc.getContent();
+					break;
+				case WHO:
+					response.who = pc.getContent();
+					break;
+				case WHY:
+					response.why = pc.getContent();
+					break;
+				case WHAT:
+					response.what = pc.getContent();
+					break;
+				case WHEN:
+					response.when = pc.getContent();
+					break;
+				case WHERE:
+					response.where = pc.getContent();
+					break;
+				case SUMMARY:
+					response.summary = pc.getContent();
+					break;
+				case PREDICT:
+					response.predict = pc.getContent();
+					break;
+				default:
+			}
+		});
+		return response;
+	}
+}
+
+

--- a/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/Nie.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/Nie.java
@@ -34,7 +34,7 @@ public class Nie extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "nie_id")
-	private long id;
+	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "group_user_id")

--- a/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/NieContext.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/NieContext.java
@@ -1,6 +1,5 @@
 package com.ada.earthvalley.yomojomo.nie.entities;
 
-import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -17,5 +16,5 @@ import lombok.NoArgsConstructor;
 public class NieContext {
 	@Enumerated(EnumType.STRING)
 	private NieProcessType lastProcess;
-	private long articleCursor;
+	private Integer articleCursor;
 }

--- a/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/NieProcess.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/NieProcess.java
@@ -15,10 +15,13 @@ import com.ada.earthvalley.yomojomo.common.baseEntities.BaseEntity;
 import com.ada.earthvalley.yomojomo.nie.entities.enums.NieProcessType;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+// TODO: AllArgs 생성자 리팩터링 (by Leo - 22.11.07)
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class NieProcess extends BaseEntity {

--- a/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/NieProcess.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/NieProcess.java
@@ -25,7 +25,7 @@ public class NieProcess extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column
-	private long id;
+	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "nie_id")

--- a/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/enums/NieProcessType.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/nie/entities/enums/NieProcessType.java
@@ -1,7 +1,7 @@
 package com.ada.earthvalley.yomojomo.nie.entities.enums;
 
 public enum NieProcessType {
-	GUESSING,
+	PREDICT,
 	READING,
 	WHEN,
 	WHO,

--- a/src/main/java/com/ada/earthvalley/yomojomo/nie/exceptions/NieError.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/nie/exceptions/NieError.java
@@ -1,0 +1,33 @@
+package com.ada.earthvalley.yomojomo.nie.exceptions;
+
+import static com.ada.earthvalley.yomojomo.common.exceptions.ErrorCode.*;
+
+import org.springframework.http.HttpStatus;
+
+import com.ada.earthvalley.yomojomo.common.exceptions.ErrorCode;
+import com.ada.earthvalley.yomojomo.common.exceptions.ErrorInfo;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum NieError implements ErrorInfo {
+	NIE_NOT_FOUND(ERR1000);
+
+	private final ErrorCode code;
+
+	@Override
+	public String getMessage() {
+		return code.getMessage();
+	}
+
+	@Override
+	public int getCode() {
+		return code.getCode();
+	}
+
+	@Override
+	public HttpStatus getStatus() {
+		return code.getStatus();
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/nie/exceptions/YomojomoNieException.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/nie/exceptions/YomojomoNieException.java
@@ -1,0 +1,10 @@
+package com.ada.earthvalley.yomojomo.nie.exceptions;
+
+import com.ada.earthvalley.yomojomo.common.exceptions.ErrorInfo;
+import com.ada.earthvalley.yomojomo.common.exceptions.YomojomoException;
+
+public class YomojomoNieException extends YomojomoException {
+	public YomojomoNieException(ErrorInfo info) {
+		super(info);
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/nie/repositories/NieRepository.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/nie/repositories/NieRepository.java
@@ -1,0 +1,8 @@
+package com.ada.earthvalley.yomojomo.nie.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ada.earthvalley.yomojomo.nie.entities.Nie;
+
+public interface NieRepository extends JpaRepository<Nie, Long> {
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/nie/services/NieFetchServiceV1.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/nie/services/NieFetchServiceV1.java
@@ -1,0 +1,26 @@
+package com.ada.earthvalley.yomojomo.nie.services;
+
+import static com.ada.earthvalley.yomojomo.nie.exceptions.NieError.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ada.earthvalley.yomojomo.nie.dtos.FetchNieResponse;
+import com.ada.earthvalley.yomojomo.nie.entities.Nie;
+import com.ada.earthvalley.yomojomo.nie.exceptions.YomojomoNieException;
+import com.ada.earthvalley.yomojomo.nie.repositories.NieRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class NieFetchServiceV1 {
+	private final NieRepository nieRepository;
+
+	public FetchNieResponse fetchNie(Long nieId) throws YomojomoNieException {
+		Nie nie = nieRepository.findById(nieId)
+			.orElseThrow(() -> new YomojomoNieException(NIE_NOT_FOUND));
+		return FetchNieResponse.of(nie);
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/user/entities/User.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/user/entities/User.java
@@ -35,7 +35,7 @@ import lombok.NoArgsConstructor;
 public class User extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
-	@Column(name = "user_id")
+	@Column(name = "user_id", columnDefinition = "uuid")
 	private UUID id;
 
 	private String username;

--- a/src/main/java/com/ada/earthvalley/yomojomo/user/entities/UserTopic.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/user/entities/UserTopic.java
@@ -23,7 +23,7 @@ public class UserTopic extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "user_topic_id")
-	private long id;
+	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")

--- a/src/main/java/com/ada/earthvalley/yomojomo/word/entities/Word.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/word/entities/Word.java
@@ -23,7 +23,7 @@ public class Word extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "word_id")
-	private long id;
+	private Long id;
 
 	private String word;
 

--- a/src/main/java/com/ada/earthvalley/yomojomo/word/entities/WordContext.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/word/entities/WordContext.java
@@ -22,7 +22,7 @@ public class WordContext extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "word_context_id")
-	private long id;
+	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "word_id")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,3 +32,12 @@ spring:
     properties:
       hibernate:
         format_sql: true
+---
+# Check Filters Registered
+spring:
+  config:
+    activate.on-profile: filters-registered
+
+logging:
+  level:
+    org.springframework.security.web.FilterChainProxy: DEBUG

--- a/src/test/java/com/ada/earthvalley/yomojomo/common/baseEntities/BaseEntityTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/common/baseEntities/BaseEntityTest.java
@@ -1,0 +1,47 @@
+package com.ada.earthvalley.yomojomo.common.baseEntities;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ada.earthvalley.yomojomo.word.entities.Word;
+
+@Transactional
+@SpringBootTest
+public class BaseEntityTest {
+	@PersistenceContext
+	private EntityManager em;
+
+	@DisplayName("BaseEntity - 성공")
+	@Test
+	void baseentity_success() throws
+		NoSuchMethodException,
+		InvocationTargetException,
+		InstantiationException,
+		IllegalAccessException {
+		// given
+		Constructor<Word> constructor = Word.class.getDeclaredConstructor();
+		constructor.setAccessible(true);
+		Word word = constructor.newInstance();
+
+		// when
+		em.persist(word);
+		em.flush();
+		em.clear();
+		Word findWord = em.find(Word.class, word.getId());
+
+		// then
+		assertThat(findWord).isNotNull();
+		assertThat(findWord.getCreatedAt()).isNotNull();
+		assertThat(findWord.getUpdatedAt()).isNotNull();
+	}
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/common/exceptions/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/common/exceptions/GlobalExceptionHandlerTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -21,7 +20,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import com.ada.earthvalley.yomojomo.auth.jwt.BearerAuthenticationConverter;
 import com.ada.earthvalley.yomojomo.common.exceptions.handler.GlobalExceptionHandler;
 
-@WebMvcTest
+@WebMvcTest(ExceptionTestController.class)
 class GlobalExceptionHandlerTest {
 	private MockMvc mockMvc;
 	@MockBean

--- a/src/test/java/com/ada/earthvalley/yomojomo/nie/controllers/NieControllerV1Test.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/nie/controllers/NieControllerV1Test.java
@@ -1,0 +1,116 @@
+package com.ada.earthvalley.yomojomo.nie.controllers;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.lang.reflect.Constructor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.ada.earthvalley.yomojomo.auth.JwtAuthenticationFilter;
+import com.ada.earthvalley.yomojomo.common.exceptions.handler.GlobalExceptionHandler;
+import com.ada.earthvalley.yomojomo.nie.dtos.FetchNieResponse;
+import com.ada.earthvalley.yomojomo.nie.exceptions.NieError;
+import com.ada.earthvalley.yomojomo.nie.exceptions.YomojomoNieException;
+import com.ada.earthvalley.yomojomo.nie.services.NieFetchServiceV1;
+
+@WebMvcTest(
+	controllers = NieControllerV1.class,
+	excludeFilters = {
+		@ComponentScan.Filter(
+			type = FilterType.ASSIGNABLE_TYPE,
+			classes = {
+				JwtAuthenticationFilter.class
+			})
+	}
+)
+class NieControllerV1Test {
+	MockMvc mockMvc;
+	@Autowired
+	NieControllerV1 controller;
+	@MockBean
+	NieFetchServiceV1 nieFetchService;
+
+	private static final String FETCH_URI = "/api/v1/nies/{nieId}";
+
+	@BeforeEach
+	void initEach() {
+		mockMvc = MockMvcBuilders
+			.standaloneSetup(controller)
+			.setControllerAdvice(GlobalExceptionHandler.class)
+			.build();
+	}
+
+	@DisplayName("fetch - 실패 (nie 없음)")
+	@Test
+	void fetch_fail() throws Exception {
+		// given
+		NieError errorInfo = NieError.NIE_NOT_FOUND;
+		// when
+		doThrow(new YomojomoNieException(errorInfo))
+			.when(nieFetchService)
+			.fetchNie(anyLong());
+
+		// then
+		mockMvc.perform(MockMvcRequestBuilders.get(FETCH_URI, 1L))
+			.andDo(print())
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message", errorInfo.getMessage()).exists())
+			.andExpect(jsonPath("$.status", errorInfo.getStatus()).exists())
+			.andExpect(jsonPath("$.code", errorInfo.getCode()).exists())
+			.andExpect(jsonPath("$.timestamp").exists());
+
+		verify(nieFetchService, times(1)).fetchNie(anyLong());
+	}
+
+	@DisplayName("fetch - 성공 ")
+	@Test
+	void fetch_success() throws Exception {
+		// given
+		Constructor<FetchNieResponse> constructor = FetchNieResponse.class.getDeclaredConstructor();
+		constructor.setAccessible(true);
+		FetchNieResponse response = constructor.newInstance();
+		ReflectionTestUtils.setField(response, "predict", "예측");
+		ReflectionTestUtils.setField(response, "where", "어디");
+		ReflectionTestUtils.setField(response, "why", "왜");
+		ReflectionTestUtils.setField(response, "what", "무엇을");
+		ReflectionTestUtils.setField(response, "when", "언제");
+		ReflectionTestUtils.setField(response, "who", "누가");
+		ReflectionTestUtils.setField(response, "how", "어떻게");
+		ReflectionTestUtils.setField(response, "summary", "요약");
+
+		// when
+		when(nieFetchService.fetchNie(anyLong()))
+			.thenReturn(response);
+
+		// then
+		mockMvc.perform(
+				MockMvcRequestBuilders.get(FETCH_URI, 1L))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.predict", is("예측")))
+			.andExpect(jsonPath("$.where", is("어디")))
+			.andExpect(jsonPath("$.why", is("왜")))
+			.andExpect(jsonPath("$.what", is("무엇을")))
+			.andExpect(jsonPath("$.when", is("언제")))
+			.andExpect(jsonPath("$.who", is("누가")))
+			.andExpect(jsonPath("$.how", is("어떻게")))
+			.andExpect(jsonPath("$.summary", is("요약")));
+
+		verify(nieFetchService, times(1)).fetchNie(anyLong());
+	}
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/nie/repositories/NieRepositoryTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/nie/repositories/NieRepositoryTest.java
@@ -1,0 +1,75 @@
+package com.ada.earthvalley.yomojomo.nie.repositories;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import com.ada.earthvalley.yomojomo.nie.entities.Nie;
+
+@DataJpaTest
+class NieRepositoryTest {
+	@Autowired
+	NieRepository nieRepository;
+	@PersistenceContext
+	EntityManager em;
+
+	Nie nie1;
+	Nie nie2;
+	Nie nie3;
+	Nie nie4;
+
+	@BeforeEach
+	void initEach() throws
+		NoSuchMethodException,
+		InvocationTargetException,
+		InstantiationException,
+		IllegalAccessException {
+		// TODO: Nie Builder 설정 시 refactoring (by Leo - 22.11.04)
+		Constructor<Nie> nieConstructor = Nie.class.getDeclaredConstructor();
+		nieConstructor.setAccessible(true);
+		nie1 = nieConstructor.newInstance();
+		nie2 = nieConstructor.newInstance();
+		nie3 = nieConstructor.newInstance();
+		nie4 = nieConstructor.newInstance();
+
+		for (Nie nie : Arrays.asList(nie1, nie2, nie3, nie4)) {
+			em.persist(nie);
+		}
+		em.flush();
+		em.clear();
+	}
+
+	@DisplayName("findAll - 성공")
+	@Test
+	void find_all_success() {
+		// when
+		List<Nie> all = nieRepository.findAll();
+
+		// then
+		assertThat(all).hasSize(4);
+	}
+
+	@DisplayName("findById - 성공")
+	@Test
+	void find_by_id_success() {
+		// when
+		Optional<Nie> nie = nieRepository.findById(nie1.getId());
+
+		// then
+		assertThat(nie).isNotEmpty();
+	}
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/nie/services/NieFetchServiceV1Test.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/nie/services/NieFetchServiceV1Test.java
@@ -1,0 +1,91 @@
+package com.ada.earthvalley.yomojomo.nie.services;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.ada.earthvalley.yomojomo.nie.dtos.FetchNieResponse;
+import com.ada.earthvalley.yomojomo.nie.entities.Nie;
+import com.ada.earthvalley.yomojomo.nie.entities.NieProcess;
+import com.ada.earthvalley.yomojomo.nie.entities.enums.NieProcessType;
+import com.ada.earthvalley.yomojomo.nie.exceptions.YomojomoNieException;
+import com.ada.earthvalley.yomojomo.nie.repositories.NieRepository;
+
+@ExtendWith(MockitoExtension.class)
+class NieFetchServiceV1Test {
+	@Mock
+	NieRepository nieRepository;
+
+	@InjectMocks
+	NieFetchServiceV1 nieFetchService;
+
+	Nie nie1;
+
+	@BeforeEach
+	void initEach() throws
+		NoSuchMethodException,
+		InvocationTargetException,
+		InstantiationException,
+		IllegalAccessException {
+		Constructor<Nie> nieConstructor = Nie.class.getDeclaredConstructor();
+		nieConstructor.setAccessible(true);
+		nie1 = nieConstructor.newInstance();
+		NieProcess how = new NieProcess(null, null, NieProcessType.HOW, "어떻게");
+		NieProcess predict = new NieProcess(null, null, NieProcessType.PREDICT, "예측");
+		NieProcess what = new NieProcess(null, null, NieProcessType.WHAT, "무엇을");
+		NieProcess summary = new NieProcess(null, null, NieProcessType.SUMMARY, "요약");
+		NieProcess when = new NieProcess(null, null, NieProcessType.WHEN, "언제");
+		NieProcess where = new NieProcess(null, null, NieProcessType.WHERE, "어디서");
+		NieProcess who = new NieProcess(null, null, NieProcessType.WHO, "누가");
+		NieProcess why = new NieProcess(null, null, NieProcessType.WHY, "왜");
+		ReflectionTestUtils.setField(nie1, "processes",
+			Arrays.asList(how, predict, what, summary, when, where, who, why));
+	}
+
+	@DisplayName("fetchNie - 실패 (nie 없음)")
+	@Test
+	void fetch_nie_fail_not_found() {
+		// when
+		when(nieRepository.findById(anyLong()))
+			.thenReturn(Optional.empty());
+
+		// then
+		assertThatThrownBy(() -> nieFetchService.fetchNie(1L))
+			.isInstanceOf(YomojomoNieException.class);
+	}
+
+	@DisplayName("fetchNie - 성공")
+	@Test
+	void fetch_nie_success() {
+		// when
+		when(nieRepository.findById(anyLong()))
+			.thenReturn(Optional.of(nie1));
+		FetchNieResponse response = nieFetchService.fetchNie(1L);
+
+		// then
+		assertNotNull(response);
+		assertThat(response.getHow()).isEqualTo("어떻게");
+		assertThat(response.getWhen()).isEqualTo("언제");
+		assertThat(response.getWhere()).isEqualTo("어디서");
+		assertThat(response.getWhat()).isEqualTo("무엇을");
+		assertThat(response.getSummary()).isEqualTo("요약");
+		assertThat(response.getPredict()).isEqualTo("예측");
+		assertThat(response.getWhy()).isEqualTo("왜");
+		assertThat(response.getWho()).isEqualTo("누가");
+	}
+
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/user/entities/UserTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/user/entities/UserTest.java
@@ -1,0 +1,41 @@
+package com.ada.earthvalley.yomojomo.user.entities;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+public class UserTest {
+	@PersistenceContext
+	private EntityManager em;
+
+	@DisplayName("User find - 성공")
+	@Test
+	void user_find_success() throws
+		NoSuchMethodException,
+		InvocationTargetException,
+		InstantiationException,
+		IllegalAccessException {
+		// given
+		Constructor<User> constructor = User.class.getDeclaredConstructor();
+		constructor.setAccessible(true);
+		User user = constructor.newInstance();
+
+		// when
+		em.persist(user);
+		em.flush();
+		em.clear();
+		User findUser = em.find(User.class, user.getId());
+
+		// then
+		assertThat(findUser).isNotNull();
+	}
+}


### PR DESCRIPTION
## 작업 개요
<!-- ex) 고양이가 야옹 소리를 내도록 수정 -->
단일 NIE 조회 API 구현 및 테스트

## 이슈 티켓
<!-- ex) 작업한 이슈를 태그하세요. -->
- #41 

## 작업 분류
- [x] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [x] 테스트 코드 작성
- [x] 설정


## 작업 상세 내용
<!--  ex) 1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴 -->

### Filter chain 테스트용 설정 추가
- filters-registered 프로파일을 켜야 확인할 수 있습니다.

### Security Config 설정 변경
- JwtAuthenticationFilter가 다음으로 넘어갈 수 있도록 doFilterInternal 메서드 안에서 doFilter 호출
- 모든 request에 대해서 인증을 요구하지 않습니다.

 **Why**
 1st spint에서는 일단 모든 유저가 anonymous한 상태로 앱을 이용하므로.

### Nie 도메인의 에러 추가 
- ErrorCode 에 반영
- NieError enum class 생성
- YomojomoNieException 커스텀 익셉션 생성

### API 구현 및 테스트 (Controller, service, Repository)


### 기타 변경사항 
- NieContext.java
  - articleCursor column의 타입을 primitive -> wrapper 타입으로 변경
  - 자세한 내용은 trouble shooting log 확인 ([https://github.com/DeveloperAcademy-POSTECH/MacC-Team-EarthValley80-Server/wiki/@Basic-어노테이션.-그리고-primitive-type에-대해-not-null-제약조건을-매핑하는-이유](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-EarthValley80-Server/wiki/@Basic-%EC%96%B4%EB%85%B8%ED%85%8C%EC%9D%B4%EC%85%98.-%EA%B7%B8%EB%A6%AC%EA%B3%A0-primitive-type%EC%97%90-%EB%8C%80%ED%95%B4-not-null-%EC%A0%9C%EC%95%BD%EC%A1%B0%EA%B1%B4%EC%9D%84-%EB%A7%A4%ED%95%91%ED%95%98%EB%8A%94-%EC%9D%B4%EC%9C%A0))
- NieProcess.java
  - AllArgs 생성자 붙임
- NieProcessType.java
  - 예측하기 단계의 네이밍 GUESSING -> PREDICT
- GlobalExceptionHandlerTest.java
  - scope을 테스트 대상 controller로 좁힘



## 생각해볼 문제
<!-- 1. wav 파일을 매번 입력하기 귀찮겠다. -->



