### PR TITLE
[Feat] JwtUtilsService 클래스 정의

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,4 +131,7 @@ gradle-app.setting
 # Java heap dump
 *.hprof
 
+# 모든 구분된 profile의 property 파일을 무시함.
+/**/resources/application**.yml
+
 # End of https://www.toptal.com/developers/gitignore/api/gradle,intellij,java,macos

--- a/build.gradle
+++ b/build.gradle
@@ -27,13 +27,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-
     implementation 'io.github.boostchicken:spring-data-dynamodb:5.2.3'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testCompileOnly 'org.projectlombok:lombok'
 
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'
 

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/JwtAuthenticationFilter.java
@@ -12,6 +12,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.ada.earthvalley.yomojomo.auth.jwt.BearerAuthenticationConverter;
 import com.ada.earthvalley.yomojomo.auth.jwt.JwtAuthenticationToken;
+import com.ada.earthvalley.yomojomo.auth.jwt.JwtUtilsService;
+import com.ada.earthvalley.yomojomo.auth.jwt.dtos.YomojomoClaim;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,11 +21,13 @@ import lombok.RequiredArgsConstructor;
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private final BearerAuthenticationConverter converter;
+	private final JwtUtilsService jwtUtilsService;
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
-		JwtAuthenticationToken convert = converter.convert(request);
+		JwtAuthenticationToken authentication = converter.convert(request);
+		YomojomoClaim claim = jwtUtilsService.verify(authentication.getCredentials());
 		filterChain.doFilter(request, response);
 	}
 

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/exceptions/AuthError.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/exceptions/AuthError.java
@@ -1,0 +1,35 @@
+package com.ada.earthvalley.yomojomo.auth.exceptions;
+
+import static com.ada.earthvalley.yomojomo.common.exceptions.ErrorCode.*;
+
+import org.springframework.http.HttpStatus;
+
+import com.ada.earthvalley.yomojomo.common.exceptions.ErrorCode;
+import com.ada.earthvalley.yomojomo.common.exceptions.ErrorInfo;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum AuthError implements ErrorInfo {
+	ILLEGAL_AUTH_HEADER(ERR2000),
+	INVALID_JWT(ERR2001),
+	JWT_EXPIRED(ERR2002);
+
+	private final ErrorCode code;
+
+	@Override
+	public String getMessage() {
+		return code.getMessage();
+	}
+
+	@Override
+	public int getCode() {
+		return code.getCode();
+	}
+
+	@Override
+	public HttpStatus getStatus() {
+		return code.getStatus();
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/exceptions/YomojomoAuthException.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/exceptions/YomojomoAuthException.java
@@ -1,0 +1,10 @@
+package com.ada.earthvalley.yomojomo.auth.exceptions;
+
+import com.ada.earthvalley.yomojomo.common.exceptions.ErrorInfo;
+import com.ada.earthvalley.yomojomo.common.exceptions.YomojomoException;
+
+public class YomojomoAuthException extends YomojomoException {
+	public YomojomoAuthException(ErrorInfo info) {
+		super(info);
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/jwt/BearerAuthenticationConverter.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/jwt/BearerAuthenticationConverter.java
@@ -1,11 +1,14 @@
 package com.ada.earthvalley.yomojomo.auth.jwt;
 
+import static com.ada.earthvalley.yomojomo.auth.exceptions.AuthError.*;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.web.authentication.AuthenticationConverter;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
 
+import com.ada.earthvalley.yomojomo.auth.exceptions.YomojomoAuthException;
 
 // TODO: 싱글톤으로 리팩터링 (by Leo - 22.10.30)
 // TODO: Exception 수정 (by Leo - 22.10.30)
@@ -22,12 +25,12 @@ public class BearerAuthenticationConverter implements AuthenticationConverter {
         header = header.trim();
         String[] splited = header.split(" ");
         if (splited.length != 2) {
-            throw new IllegalArgumentException("올바르지 않은 형식");
+            throw new YomojomoAuthException(ILLEGAL_AUTH_HEADER);
         }
         final String scheme = splited[0];
         final String token = splited[1];
         if (!AUTHENTICATION_SCHEME.equals(scheme)) {
-            throw new IllegalArgumentException("Bearer 가 아님");
+            throw new YomojomoAuthException(ILLEGAL_AUTH_HEADER);
         }
         return JwtAuthenticationToken.unauthenticated(token);
     }

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/jwt/JwtSecretsService.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/jwt/JwtSecretsService.java
@@ -1,0 +1,28 @@
+package com.ada.earthvalley.yomojomo.auth.jwt;
+
+import java.security.Key;
+import java.util.Date;
+
+import org.springframework.stereotype.Service;
+
+import com.ada.earthvalley.yomojomo.common.propertyServices.JwtPropertyService;
+
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+
+@Service
+public class JwtSecretsService extends JwtPropertyService {
+	private static final long TOKEN_VALID_TIME = 10 * 60 * 60 * 1000L;
+
+	public Date getIssuedAt() {
+		return new Date();
+	}
+
+	public Date getExpiredAt() {
+		return new Date(getIssuedAt().getTime() + TOKEN_VALID_TIME);
+	}
+
+	public Key getSecretKey() {
+		return Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(super.secret));
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/jwt/JwtUtilsService.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/jwt/JwtUtilsService.java
@@ -1,0 +1,58 @@
+package com.ada.earthvalley.yomojomo.auth.jwt;
+
+import static com.ada.earthvalley.yomojomo.auth.exceptions.AuthError.*;
+
+import org.springframework.stereotype.Service;
+
+import com.ada.earthvalley.yomojomo.auth.exceptions.YomojomoAuthException;
+import com.ada.earthvalley.yomojomo.auth.jwt.dtos.YomojomoClaim;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.InvalidClaimException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.InvalidKeyException;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class JwtUtilsService {
+	private final JwtSecretsService jwtSecretsService;
+
+	public YomojomoClaim verify(String jwsString) throws YomojomoAuthException {
+		return verify(parseJws(jwsString));
+	}
+
+	public String create(YomojomoClaim claim) throws InvalidKeyException {
+		return Jwts.builder()
+			.setSubject(claim.getUserId())
+			.setIssuer(jwtSecretsService.getIssuer())
+			.setIssuedAt(jwtSecretsService.getIssuedAt())
+			.setExpiration(jwtSecretsService.getExpiredAt())
+			.signWith(jwtSecretsService.getSecretKey())
+			.compact();
+	}
+
+	private Jws<Claims> parseJws(String jwsString) throws YomojomoAuthException {
+		try {
+			return Jwts.parserBuilder()
+				.requireIssuer(jwtSecretsService.getIssuer())
+				.setSigningKey(jwtSecretsService.getSecretKey())
+				.build()
+				.parseClaimsJws(jwsString);
+		} catch (InvalidClaimException | SignatureException | UnsupportedJwtException | MalformedJwtException e) {
+			throw new YomojomoAuthException(INVALID_JWT);
+		} catch (ExpiredJwtException e) {
+			throw new YomojomoAuthException(JWT_EXPIRED);
+		}
+	}
+
+	// Claim 검증 후 throw
+	private YomojomoClaim verify(Jws<Claims> claims) throws YomojomoAuthException {
+		return YomojomoClaim.of(claims.getBody());
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/jwt/dtos/YomojomoClaim.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/jwt/dtos/YomojomoClaim.java
@@ -1,0 +1,20 @@
+package com.ada.earthvalley.yomojomo.auth.jwt.dtos;
+
+import java.util.UUID;
+
+import io.jsonwebtoken.Claims;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class YomojomoClaim {
+	private UUID userId;
+
+	public String getUserId() {
+		return userId.toString();
+	}
+
+	public static YomojomoClaim of(Claims claims) {
+		return new YomojomoClaim(UUID.fromString(claims.getSubject()));
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/common/exceptions/ErrorCode.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/common/exceptions/ErrorCode.java
@@ -9,7 +9,11 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
-	ERR1000(1000, HttpStatus.NOT_FOUND, "NIE가 존재하지 않습니다.");
+	ERR1000(1000, HttpStatus.NOT_FOUND, "NIE가 존재하지 않습니다."),
+
+	ERR2000(2000, HttpStatus.BAD_REQUEST, "인증 헤더가 형식에 맞지 않습니다."),
+	ERR2001(2001, HttpStatus.UNAUTHORIZED, "올바르지 않은 인증 토큰입니다."),
+	ERR2002(2002, HttpStatus.UNAUTHORIZED, "인증 토큰이 만료되었습니다.");
 
 	private final int code;
 	private final HttpStatus status;

--- a/src/main/java/com/ada/earthvalley/yomojomo/common/propertyServices/JwtPropertyService.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/common/propertyServices/JwtPropertyService.java
@@ -1,0 +1,15 @@
+package com.ada.earthvalley.yomojomo.common.propertyServices;
+
+import org.springframework.beans.factory.annotation.Value;
+
+import lombok.Getter;
+
+// TODO: @ConfigurationProperties 를 이용해 Refactoring (by Leo - 22.11.15)
+public class JwtPropertyService {
+	@Getter
+	@Value("${jwt.claims.issuer}")
+	protected String issuer;
+
+	@Value("${jwt.secret-key}")
+	protected String secret;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: local-postgresql, dev
+    active: local-postgresql, dev, jwt
 
 ---
 # Local PostgreSQL
@@ -18,6 +18,10 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQL82Dialect
 
+jwt:
+  claims:
+    issuer: "yomojomo.com"
+  secret-key: "yomojomo-05f92a6d-eb05-451d-a102-36e6450a5e97"
 ---
 # Dev Defaults
 spring:

--- a/src/test/java/com/ada/earthvalley/yomojomo/auth/jwt/BearerAuthenticationConverterTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/auth/jwt/BearerAuthenticationConverterTest.java
@@ -8,6 +8,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
+import com.ada.earthvalley.yomojomo.auth.exceptions.YomojomoAuthException;
+import com.ada.earthvalley.yomojomo.common.exceptions.ErrorCode;
+
 class BearerAuthenticationConverterTest {
 	private static final String AUTHORIZATION_HEADER = "Authorization";
 	private BearerAuthenticationConverter converter;
@@ -33,9 +36,9 @@ class BearerAuthenticationConverterTest {
 		request.addHeader("Authorization", " bearer token token");
 
 		// when, then
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+		YomojomoAuthException exception = assertThrows(YomojomoAuthException.class,
 			() -> converter.convert(request));
-		assertThat(exception.getMessage()).isEqualTo("올바르지 않은 형식");
+		assertThat(exception.getMessage()).isEqualTo(ErrorCode.ERR2000.getMessage());
 	}
 
 	@Test
@@ -44,9 +47,9 @@ class BearerAuthenticationConverterTest {
 		// given
 		request.addHeader(AUTHORIZATION_HEADER, "Basic LeoBang");
 		// when, then
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+		YomojomoAuthException exception = assertThrows(YomojomoAuthException.class,
 			() -> converter.convert(request));
-		assertThat(exception.getMessage()).isEqualTo("Bearer 가 아님");
+		assertThat(exception.getMessage()).isEqualTo(ErrorCode.ERR2000.getMessage());
 	}
 
 	@Test

--- a/src/test/java/com/ada/earthvalley/yomojomo/auth/jwt/JwtUtilsServiceTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/auth/jwt/JwtUtilsServiceTest.java
@@ -1,0 +1,130 @@
+package com.ada.earthvalley.yomojomo.auth.jwt;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.ada.earthvalley.yomojomo.auth.exceptions.YomojomoAuthException;
+import com.ada.earthvalley.yomojomo.auth.jwt.dtos.YomojomoClaim;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+@ExtendWith(MockitoExtension.class)
+class JwtUtilsServiceTest {
+	@Mock
+	private JwtSecretsService jwtSecretsService;
+
+	@InjectMocks
+	private JwtUtilsService jwtUtilsService;
+	private Key secretKey;
+
+	@BeforeEach
+	void init() {
+		secretKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+		when(jwtSecretsService.getIssuer())
+			.thenReturn("yomojomo.com");
+		when(jwtSecretsService.getSecretKey())
+			.thenReturn(secretKey);
+	}
+
+	@DisplayName("parseJws - 실패 (secret key 불일치)")
+	@Test
+	void parseJws_failure_invalid_secret_key() {
+		// given
+		String jws = Jwts.builder()
+			.signWith(Keys.secretKeyFor(SignatureAlgorithm.HS256))
+			.compact();
+
+		// when, then
+		assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(jwtUtilsService, "parseJws", jws))
+			.isInstanceOf(YomojomoAuthException.class);
+	}
+
+	@DisplayName("parseJws - 실패 (issuer 불일치)")
+	@Test
+	void parseJws_failure_invalid_issuer() {
+		// given
+		String jws = Jwts.builder()
+			.setIssuer("random_issuer")
+			.signWith(jwtSecretsService.getSecretKey())
+			.compact();
+
+		// when, then
+		assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(jwtUtilsService, "parseJws", jws))
+			.isInstanceOf(YomojomoAuthException.class);
+	}
+
+	@DisplayName("parseJws - 실패 (토큰 만료)")
+	@Test
+	void parseJws_failure_expired() {
+		// given
+		String jws = Jwts.builder()
+			.setIssuer(jwtSecretsService.getIssuer())
+			.signWith(jwtSecretsService.getSecretKey())
+			.setExpiration(new Date())
+			.compact();
+
+		// when, then
+		assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(jwtUtilsService, "parseJws", jws))
+			.isInstanceOf(YomojomoAuthException.class);
+	}
+
+	@DisplayName("parseJws - 성공")
+	@Test
+	void parseJws_success() {
+		// given
+		String jws = Jwts.builder()
+			.setIssuer(jwtSecretsService.getIssuer())
+			.signWith(jwtSecretsService.getSecretKey())
+			.setSubject("subject")
+			.claim("username", "leo")
+			.setExpiration(new Date(new Date().getTime() + 60 * 1000L))
+			.compact();
+
+		// when
+		Jws<Claims> parsedJws = (Jws<Claims>)ReflectionTestUtils.invokeMethod(jwtUtilsService, "parseJws", jws);
+		Claims claims = parsedJws.getBody();
+		JwsHeader header = parsedJws.getHeader();
+
+		// then
+		assertThat(claims.getSubject()).isEqualTo("subject");
+		assertThat(claims.get("username")).isEqualTo("leo");
+		assertThat(header.getAlgorithm()).isEqualTo(SignatureAlgorithm.HS256.toString());
+	}
+
+	@DisplayName("verify - 성공")
+	@Test
+	void verify_success() {
+		// given
+		UUID uuid = UUID.randomUUID();
+		String jws = Jwts.builder()
+			.setIssuer(jwtSecretsService.getIssuer())
+			.signWith(jwtSecretsService.getSecretKey())
+			.setSubject(uuid.toString())
+			.setExpiration(new Date(new Date().getTime() + 60 * 1000L))
+			.compact();
+
+		// when
+		YomojomoClaim verify = jwtUtilsService.verify(jws);
+
+		// then
+		assertThat(verify.getUserId()).isEqualTo(uuid.toString());
+	}
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/common/PropertyInjectionTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/common/PropertyInjectionTest.java
@@ -1,0 +1,30 @@
+package com.ada.earthvalley.yomojomo.common;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.ada.earthvalley.yomojomo.common.propertyServices.JwtPropertyService;
+
+@DisplayName("@Value를 이용한 property 주입 테스트")
+@SpringBootTest
+public class PropertyInjectionTest {
+	@Autowired
+	private JwtPropertyService jwtPropertyService;
+
+	// TODO: @Value 가 main path의 값을 가져오도록 테스트 (by Leo - 22.11.15)
+	@DisplayName("JwtSecretsService 프로퍼티 테스트")
+	@Test
+	void jwtSecrets() {
+		String secret = (String)ReflectionTestUtils.getField(jwtPropertyService, "secret");
+		String issuer = jwtPropertyService.getIssuer();
+
+		assertThat(jwtPropertyService).isNotNull();
+		assertThat(issuer).isNotNull();
+		assertThat(secret).isNotNull();
+	}
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/common/exceptions/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/common/exceptions/GlobalExceptionHandlerTest.java
@@ -11,22 +11,31 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import com.ada.earthvalley.yomojomo.auth.jwt.BearerAuthenticationConverter;
+import com.ada.earthvalley.yomojomo.auth.JwtAuthenticationFilter;
 import com.ada.earthvalley.yomojomo.common.exceptions.handler.GlobalExceptionHandler;
 
-@WebMvcTest(ExceptionTestController.class)
+@WebMvcTest(
+	controllers = ExceptionTestController.class,
+	excludeFilters = {
+		@ComponentScan.Filter(
+			type = FilterType.ASSIGNABLE_TYPE,
+			classes = {JwtAuthenticationFilter.class}
+		)
+	}
+)
 class GlobalExceptionHandlerTest {
 	private MockMvc mockMvc;
 	@MockBean
 	private ErrorInfo errorInfo;
-	@MockBean
-	private BearerAuthenticationConverter converter;
+
 	@Autowired
 	ExceptionTestController controller;
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: test, h2-test-for-postgresql
+    active: test, h2-test-for-postgresql, jwt
 
 ---
 # H2 IN MEMORY TEST PROFILE


### PR DESCRIPTION
## 작업 개요
<!-- ex) 고양이가 야옹 소리를 내도록 수정 -->
Jwt를 검증하고 생성하는 책임을 지닌 JwtUtilsService 클래스를 정의 + 테스트 

## 이슈 티켓
<!-- ex) 작업한 이슈를 태그하세요. -->
- #36 


## 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [x] 프로젝트 구조 변경
- [x] 테스트 코드 작성
- [x] 설정


## 작업 상세 내용
<!--  ex) 1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴 -->

### jjwt 의존성 적용
- build.gradle 스크립트를 이용해 앱에 jjwt 의존성 적용

### jwt를 위한 profile 적용 및 .gitignore 정의

### YomojomoAuthException 정의 및 기존 코드에 적용 
(As Is)
- `BearerAuthenticationConverter`는 `RuntimeException`을 던졌음
- `BearerAuthenticationConverterTest`는 `RuntimeException`에 대해 테스트를 실행함

(To Be)
- `BearerAuthenticationConverter`는 `YomojomoAuthException`을 던짐
- `BearerAuthenticationConverterTest`는 `YomojomoAuthException` 대해 테스트를 실행함

### Jwt 관련 Service 클래스 정의 및 dto 정의
`JwtPropertyService`
- application-jwt.yml 의 프로퍼티 값을 서빙하는 단일 책임을 진다.
`JwtSecretsService`
- 앱이 이용하는 Jwt 속의 값을 서빙하는 단일 책임을 진다. (key, issuer, expiration 등)
`JwtUtilsService`
- Jws를 생성하고 검증하는 책임을 진다.
`YomojomoClaim`
- JwtUtilsService - JwtAuthenticationFilter 두 layer 사이를 연결하는 dto 클래스

### Jwt 관련 Service 클래스 테스트

### GlobalExceptionHandlerTest 수정
(As Is)
- WebMvcTest가 땡겨오지 못하는 Bean들을 MockBean으로 Context에 담아줬음

(To Be)
- 특정 클래스를 component scan에서 제외하는 방식으로 변경

Why?
- 특정 클래스의 의존관계가 점차 늘어나면서 매번 @MockBean으로 담아주기 번거로워질 것 같아서.

Todo
- SlicedTest에 제외하는 configuration 재사용 가능하도록 만들기




## 생각해볼 문제
<!-- 1. wav 파일을 매번 입력하기 귀찮겠다. -->

test path에서 /src/main/resources 의 profile에 접근할 수는 없을까? 
test 환경에서 재사용가능한 configuration 을 만드는 방법은 뭐가 있을까? 

**slack 에 올린 파일을 main과 test path 모두 적용해주세요**
