### PR TITLE
[Feat] OAuth2 로그인 및 회원가입 구현

### DIFF
--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/YomojomoOAuth2User.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/YomojomoOAuth2User.java
@@ -1,0 +1,46 @@
+package com.ada.earthvalley.yomojomo.auth;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import com.ada.earthvalley.yomojomo.auth.entities.enums.VendorType;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+public class YomojomoOAuth2User implements OAuth2User {
+	private Map<String, Object> attributes;
+	private Collection<? extends GrantedAuthority> authorities;
+	private String name;
+	@Setter
+	private VendorType vendorType;
+
+	public YomojomoOAuth2User(OAuth2User oAuth2User) {
+		attributes = oAuth2User.getAttributes();
+		authorities = oAuth2User.getAuthorities();
+		name = oAuth2User.getName();
+	}
+
+	@Override
+	public Map<String, Object> getAttributes() {
+		return attributes;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return authorities;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	public String getSocialId() {
+		return getName();
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/api/OAuth2Controller.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/api/OAuth2Controller.java
@@ -1,0 +1,38 @@
+package com.ada.earthvalley.yomojomo.auth.api;
+
+import java.util.NoSuchElementException;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ada.earthvalley.yomojomo.auth.dtos.LoginResponse;
+import com.ada.earthvalley.yomojomo.auth.YomojomoOAuth2User;
+import com.ada.earthvalley.yomojomo.auth.YomojomoUser;
+import com.ada.earthvalley.yomojomo.auth.services.OAuth2ApiService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/oauth2")
+@RestController
+public class OAuth2Controller {
+	private final OAuth2ApiService authApiService;
+
+	@GetMapping("/login")
+	public ResponseEntity<LoginResponse> login(@YomojomoUser YomojomoOAuth2User user) {
+		try {
+			return ResponseEntity.ok(authApiService.oauth2LoginOrSignUp(user));
+		} catch (NoSuchElementException e) {
+			return ResponseEntity.status(HttpStatus.FOUND).header(HttpHeaders.LOCATION, "/api/oauth2/signup").build();
+		}
+	}
+
+	@GetMapping("/signup")
+	public ResponseEntity<LoginResponse> signup(@YomojomoUser YomojomoOAuth2User user) {
+		return ResponseEntity.ok(authApiService.oauth2SignUp(user));
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/configs/OAuth2WebSecurityConfig.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/configs/OAuth2WebSecurityConfig.java
@@ -1,0 +1,43 @@
+package com.ada.earthvalley.yomojomo.auth.configs;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+import com.ada.earthvalley.yomojomo.auth.oauth2.services.YomojomoOAuth2UserService;
+
+@EnableWebSecurity
+public class OAuth2WebSecurityConfig {
+
+	@Bean
+	public SecurityFilterChain oauth2SecurityFilterChain(HttpSecurity http) throws Exception {
+		http
+			.antMatcher("/api/oauth2/**")
+			.oauth2Login(oauth2 -> {
+				oauth2
+					.authorizationEndpoint(authorization -> {
+						authorization.baseUri("/api/oauth2/authorization");
+					})
+					.userInfoEndpoint(userInfo -> {
+						userInfo.userService(new YomojomoOAuth2UserService());
+					});
+			})
+			.authorizeRequests(c -> {
+				c
+					.anyRequest().authenticated();
+			});
+		return http.build();
+	}
+
+	@Bean
+	public SecurityFilterChain oauth2RedirectFilterChain(HttpSecurity http) throws Exception {
+		http
+			.antMatcher("/login/oauth2/**")
+			.oauth2Login(oauth2 -> {
+			})
+			.authorizeRequests()
+			.anyRequest().authenticated();
+		return http.build();
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/configs/WebSecurityConfig.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/configs/WebSecurityConfig.java
@@ -7,9 +7,9 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
-import com.ada.earthvalley.yomojomo.auth.JwtAuthenticationFilter;
+import com.ada.earthvalley.yomojomo.auth.jwt.JwtAuthenticationFilter;
 import com.ada.earthvalley.yomojomo.auth.jwt.BearerAuthenticationConverter;
-import com.ada.earthvalley.yomojomo.auth.jwt.JwtUtilsService;
+import com.ada.earthvalley.yomojomo.auth.jwt.services.JwtUtilsService;
 
 @EnableWebSecurity
 public class WebSecurityConfig {

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/dtos/LoginResponse.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/dtos/LoginResponse.java
@@ -1,0 +1,12 @@
+package com.ada.earthvalley.yomojomo.auth.dtos;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@Data
+public class LoginResponse {
+	private YomojomoToken accessToken;
+	private YomojomoToken refreshToken;
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/dtos/YomojomoToken.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/dtos/YomojomoToken.java
@@ -1,0 +1,32 @@
+package com.ada.earthvalley.yomojomo.auth.dtos;
+
+import java.time.LocalDateTime;
+
+import com.ada.earthvalley.yomojomo.auth.jwt.services.TokenTimeUtils;
+
+import lombok.Data;
+
+@Data
+public class YomojomoToken {
+	private String token;
+	private LocalDateTime iat;
+	private LocalDateTime exp;
+
+	public static YomojomoToken createAccessToken(String accessToken) {
+		YomojomoToken yomojomoToken = new YomojomoToken(accessToken);
+		yomojomoToken.exp = TokenTimeUtils.getAccessTokenLocalDateTime();
+		return yomojomoToken;
+	}
+
+	public static YomojomoToken createRefreshToken(String refreshToken) {
+		YomojomoToken yomojomoToken = new YomojomoToken(refreshToken);
+		yomojomoToken.exp = TokenTimeUtils.getRefreshTokenLocalDateTime();
+		return yomojomoToken;
+	}
+
+	private YomojomoToken(String token) {
+		this.token = token;
+		this.iat = LocalDateTime.now();
+	}
+}
+

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/RefreshToken.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/RefreshToken.java
@@ -8,6 +8,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
+import com.ada.earthvalley.yomojomo.auth.jwt.services.TokenTimeUtils;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,7 +25,11 @@ public class RefreshToken {
 
 	private String refreshToken;
 
-	private LocalDateTime expiredAt;
+	private LocalDateTime expiredAt = TokenTimeUtils.getRefreshTokenLocalDateTime();
 
 	private LocalDateTime issuedAt = LocalDateTime.now();
+
+	public RefreshToken(String refreshToken) {
+		this.refreshToken = refreshToken;
+	}
 }

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/VendorResource.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/VendorResource.java
@@ -11,6 +11,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
+import com.ada.earthvalley.yomojomo.auth.YomojomoOAuth2User;
 import com.ada.earthvalley.yomojomo.common.baseEntities.BaseEntity;
 import com.ada.earthvalley.yomojomo.auth.entities.enums.VendorType;
 import com.ada.earthvalley.yomojomo.user.entities.User;
@@ -36,4 +37,10 @@ public class VendorResource extends BaseEntity {
 
 	@Enumerated(EnumType.STRING)
 	private VendorType type;
+
+	public VendorResource(YomojomoOAuth2User oAuth2User, User user) {
+		this.user = user;
+		this.vendorId = oAuth2User.getSocialId();
+		this.type = oAuth2User.getVendorType();
+	}
 }

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/enums/VendorType.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/entities/enums/VendorType.java
@@ -2,4 +2,15 @@ package com.ada.earthvalley.yomojomo.auth.entities.enums;
 
 public enum VendorType {
 	KAKAO, APPLE;
+
+	public static VendorType typeOf(String typeString) {
+		switch (typeString) {
+			case "kakao":
+				return KAKAO;
+			case "apple":
+				return APPLE;
+			default:
+				return null;
+		}
+	}
 }

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/jwt/JwtAuthenticationFilter.java
@@ -1,4 +1,4 @@
-package com.ada.earthvalley.yomojomo.auth;
+package com.ada.earthvalley.yomojomo.auth.jwt;
 
 import java.io.IOException;
 
@@ -11,9 +11,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.ada.earthvalley.yomojomo.auth.exceptions.YomojomoAuthException;
-import com.ada.earthvalley.yomojomo.auth.jwt.BearerAuthenticationConverter;
-import com.ada.earthvalley.yomojomo.auth.jwt.JwtAuthenticationToken;
-import com.ada.earthvalley.yomojomo.auth.jwt.JwtUtilsService;
+import com.ada.earthvalley.yomojomo.auth.jwt.services.JwtUtilsService;
 import com.ada.earthvalley.yomojomo.auth.jwt.dtos.YomojomoClaim;
 import com.ada.earthvalley.yomojomo.common.exceptions.ErrorResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/jwt/dtos/YomojomoClaim.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/jwt/dtos/YomojomoClaim.java
@@ -2,6 +2,8 @@ package com.ada.earthvalley.yomojomo.auth.jwt.dtos;
 
 import java.util.UUID;
 
+import com.ada.earthvalley.yomojomo.user.entities.User;
+
 import io.jsonwebtoken.Claims;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -16,5 +18,9 @@ public class YomojomoClaim {
 
 	public static YomojomoClaim of(Claims claims) {
 		return new YomojomoClaim(UUID.fromString(claims.getSubject()));
+	}
+
+	public static YomojomoClaim ofUser(User user) {
+		return new YomojomoClaim(user.getId());
 	}
 }

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/jwt/enums/TokenType.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/jwt/enums/TokenType.java
@@ -1,0 +1,5 @@
+package com.ada.earthvalley.yomojomo.auth.jwt.enums;
+
+public enum TokenType {
+	ACCESS_TOKEN, REFRESH_TOKEN;
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/jwt/services/JwtSecretsService.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/jwt/services/JwtSecretsService.java
@@ -1,4 +1,4 @@
-package com.ada.earthvalley.yomojomo.auth.jwt;
+package com.ada.earthvalley.yomojomo.auth.jwt.services;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
@@ -6,22 +6,27 @@ import java.util.Date;
 
 import org.springframework.stereotype.Service;
 
+import com.ada.earthvalley.yomojomo.auth.jwt.enums.TokenType;
 import com.ada.earthvalley.yomojomo.common.propertyServices.JwtPropertyService;
 
-import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.io.DecodingException;
 import io.jsonwebtoken.security.Keys;
 
 @Service
 public class JwtSecretsService extends JwtPropertyService {
-	private static final long TOKEN_VALID_TIME = 10 * 60 * 60 * 1000L;
-
 	public Date getIssuedAt() {
 		return new Date();
 	}
 
-	public Date getExpiredAt() {
-		return new Date(getIssuedAt().getTime() + TOKEN_VALID_TIME);
+	public Date getExpiredAt(TokenType type) {
+		switch (type) {
+			case ACCESS_TOKEN:
+				return TokenTimeUtils.getAccessTokenExpiredDate();
+			case REFRESH_TOKEN:
+				return TokenTimeUtils.getRefreshTokenExpiredDate();
+			default:
+				return new Date();
+		}
 	}
 
 	public Key getSecretKey() throws DecodingException {

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/jwt/services/JwtUtilsService.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/jwt/services/JwtUtilsService.java
@@ -1,4 +1,4 @@
-package com.ada.earthvalley.yomojomo.auth.jwt;
+package com.ada.earthvalley.yomojomo.auth.jwt.services;
 
 import static com.ada.earthvalley.yomojomo.auth.exceptions.AuthError.*;
 
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import com.ada.earthvalley.yomojomo.auth.exceptions.YomojomoAuthException;
 import com.ada.earthvalley.yomojomo.auth.jwt.dtos.YomojomoClaim;
+import com.ada.earthvalley.yomojomo.auth.jwt.enums.TokenType;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -27,12 +28,20 @@ public class JwtUtilsService {
 		return verify(parseJws(jwsString));
 	}
 
-	public String create(YomojomoClaim claim) throws InvalidKeyException {
+	public String createAccessToken(YomojomoClaim claim) throws InvalidKeyException {
+		return create(claim, TokenType.ACCESS_TOKEN);
+	}
+
+	public String createRefreshToken(YomojomoClaim claim) throws InvalidKeyException {
+		return create(claim, TokenType.REFRESH_TOKEN);
+	}
+
+	private String create(YomojomoClaim claim, TokenType type) throws InvalidKeyException {
 		return Jwts.builder()
 			.setSubject(claim.getUserId())
 			.setIssuer(jwtSecretsService.getIssuer())
 			.setIssuedAt(jwtSecretsService.getIssuedAt())
-			.setExpiration(jwtSecretsService.getExpiredAt())
+			.setExpiration(jwtSecretsService.getExpiredAt(type))
 			.signWith(jwtSecretsService.getSecretKey())
 			.compact();
 	}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/jwt/services/TokenTimeUtils.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/jwt/services/TokenTimeUtils.java
@@ -1,0 +1,30 @@
+package com.ada.earthvalley.yomojomo.auth.jwt.services;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+public class TokenTimeUtils {
+	// Access Token 만료기한 - 1일
+	// Refresh Token 만료기한 - 30일
+	private static final long ACCESS_TOKEN_VALID_MILLI_TIME = 1 * 24 * 60 * 60 * 1000L;
+	private static final long REFRESH_TOKEN_VALID_MILLI_TIME = 30 * 24 * 60 * 60 * 1000L;
+
+	private static final long  ACCESS_TOKEN_VALID_TIME = 1 * 24 * 60 * 60L;
+	private static final long  REFRESH_TOKEN_VALID_TIME = 30 * 24 * 60 * 60L;
+
+	public static Date getAccessTokenExpiredDate() {
+		return new Date(new Date().getTime() + ACCESS_TOKEN_VALID_MILLI_TIME);
+	}
+
+	public static Date getRefreshTokenExpiredDate() {
+		return new Date(new Date().getTime() + REFRESH_TOKEN_VALID_MILLI_TIME);
+	}
+
+	public static LocalDateTime getAccessTokenLocalDateTime() {
+		return LocalDateTime.now().plusSeconds(ACCESS_TOKEN_VALID_TIME);
+	}
+
+	public static LocalDateTime getRefreshTokenLocalDateTime() {
+		return LocalDateTime.now().plusSeconds(REFRESH_TOKEN_VALID_TIME);
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/oauth2/OAuth2VendorForwardFilter.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/oauth2/OAuth2VendorForwardFilter.java
@@ -1,0 +1,39 @@
+package com.ada.earthvalley.yomojomo.auth.oauth2;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.ada.earthvalley.yomojomo.auth.YomojomoOAuth2User;
+
+public class OAuth2VendorForwardFilter extends OncePerRequestFilter {
+	public static final String LOGIN_URI = "/api/oauth2/login";
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		YomojomoOAuth2User user = (YomojomoOAuth2User) authentication.getPrincipal();
+		String forwardURI = LOGIN_URI;
+		switch (user.getVendorType()) {
+			case KAKAO:
+				forwardURI += "/kakao";
+			default:
+				request.getRequestDispatcher(forwardURI).forward(request, response);
+		}
+
+		doFilter(request, response, filterChain);
+	}
+
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+		return !request.getServletPath().matches(LOGIN_URI);
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/oauth2/services/YomojomoOAuth2UserService.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/oauth2/services/YomojomoOAuth2UserService.java
@@ -1,0 +1,30 @@
+package com.ada.earthvalley.yomojomo.auth.oauth2.services;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import com.ada.earthvalley.yomojomo.auth.entities.enums.VendorType;
+import com.ada.earthvalley.yomojomo.auth.YomojomoOAuth2User;
+
+@Service
+public class YomojomoOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+		DefaultOAuth2UserService delegate = new DefaultOAuth2UserService();
+		OAuth2User delegateUser = delegate.loadUser(userRequest);
+		YomojomoOAuth2User oAuth2User = new YomojomoOAuth2User(delegateUser);
+
+		String vendorId = userRequest.getClientRegistration().getRegistrationId();
+		switch (vendorId) {
+			case ("kakao"):
+				oAuth2User.setVendorType(VendorType.KAKAO);
+			default:
+		}
+		return oAuth2User;
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/repositories/VendorResourceRepository.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/repositories/VendorResourceRepository.java
@@ -1,0 +1,12 @@
+package com.ada.earthvalley.yomojomo.auth.repositories;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ada.earthvalley.yomojomo.auth.entities.VendorResource;
+import com.ada.earthvalley.yomojomo.auth.entities.enums.VendorType;
+
+public interface VendorResourceRepository extends JpaRepository<VendorResource, Long> {
+	Optional<VendorResource> findByVendorIdAndType(String vendorId, VendorType type);
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/services/OAuth2ApiService.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/services/OAuth2ApiService.java
@@ -1,0 +1,42 @@
+package com.ada.earthvalley.yomojomo.auth.services;
+
+import java.util.NoSuchElementException;
+
+import org.springframework.stereotype.Service;
+
+import com.ada.earthvalley.yomojomo.auth.dtos.YomojomoToken;
+import com.ada.earthvalley.yomojomo.auth.entities.VendorResource;
+import com.ada.earthvalley.yomojomo.auth.YomojomoOAuth2User;
+import com.ada.earthvalley.yomojomo.auth.dtos.LoginResponse;
+import com.ada.earthvalley.yomojomo.user.entities.User;
+import com.ada.earthvalley.yomojomo.user.services.UserDomainService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class OAuth2ApiService {
+	private final VendorResourceService vendorResourceService;
+	private final TokenDomainService tokenDomainService;
+	private final UserDomainService userDomainService;
+
+	public LoginResponse oauth2LoginOrSignUp(YomojomoOAuth2User user) throws NoSuchElementException {
+		VendorResource vendorResource = vendorResourceService.findVendorResourceOrThrow(user);
+		User userFromVendorResource = userDomainService.findByVendorResource(vendorResource);
+
+		// 존재할 경우 access token 생성, refresh token 생성 후 저장
+		YomojomoToken accessToken = tokenDomainService.createAccessToken(userFromVendorResource);
+		YomojomoToken refreshToken = tokenDomainService.createAndSaveRefreshToken(userFromVendorResource);
+
+		return new LoginResponse(accessToken, refreshToken);
+	}
+
+	public LoginResponse oauth2SignUp(YomojomoOAuth2User user) {
+		User createdUser = userDomainService.createUserWithOAuth2(user);
+
+		YomojomoToken accessToken = tokenDomainService.createAccessToken(createdUser);
+		YomojomoToken refreshToken = tokenDomainService.createAndSaveRefreshToken(createdUser);
+
+		return new LoginResponse(accessToken, refreshToken);
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/services/TokenDomainService.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/services/TokenDomainService.java
@@ -1,0 +1,36 @@
+package com.ada.earthvalley.yomojomo.auth.services;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ada.earthvalley.yomojomo.auth.dtos.YomojomoToken;
+import com.ada.earthvalley.yomojomo.auth.jwt.services.JwtUtilsService;
+import com.ada.earthvalley.yomojomo.auth.jwt.dtos.YomojomoClaim;
+import com.ada.earthvalley.yomojomo.user.entities.User;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class TokenDomainService {
+	private final JwtUtilsService jwtUtilsService;
+
+	public YomojomoToken createAccessToken(User user) {
+		YomojomoClaim claim = YomojomoClaim.ofUser(user);
+
+		// access token 생성
+		String accessToken = jwtUtilsService.createAccessToken(claim);
+		return YomojomoToken.createAccessToken(accessToken);
+	}
+
+	@Transactional
+	public YomojomoToken createAndSaveRefreshToken(User user) {
+		YomojomoClaim claim = YomojomoClaim.ofUser(user);
+
+		// refresh token 생성 후 저장
+		String refreshToken = jwtUtilsService.createRefreshToken(claim);
+		user.setRefreshToken(refreshToken);
+		return YomojomoToken.createRefreshToken(refreshToken);
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/services/VendorResourceService.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/services/VendorResourceService.java
@@ -1,0 +1,24 @@
+package com.ada.earthvalley.yomojomo.auth.services;
+
+import java.util.NoSuchElementException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ada.earthvalley.yomojomo.auth.entities.VendorResource;
+import com.ada.earthvalley.yomojomo.auth.YomojomoOAuth2User;
+import com.ada.earthvalley.yomojomo.auth.repositories.VendorResourceRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class VendorResourceService {
+	private final VendorResourceRepository vendorResourceRepository;
+
+	public VendorResource findVendorResourceOrThrow(YomojomoOAuth2User user) throws NoSuchElementException {
+		return vendorResourceRepository.findByVendorIdAndType(user.getSocialId(),
+			user.getVendorType()).orElseThrow(NoSuchElementException::new);
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/user/entities/User.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/user/entities/User.java
@@ -24,12 +24,11 @@ import com.ada.earthvalley.yomojomo.group.entities.GroupUser;
 import com.ada.earthvalley.yomojomo.user.entities.enums.UserRole;
 import com.ada.earthvalley.yomojomo.word.entities.Word;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @Entity
 @Table(name = "users")
 public class User extends BaseEntity {
@@ -59,4 +58,8 @@ public class User extends BaseEntity {
 	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
 	@JoinColumn(name = "token_id")
 	private RefreshToken refreshToken;
+
+	public void setRefreshToken(String refreshToken) {
+		this.refreshToken = new RefreshToken(refreshToken);
+	}
 }

--- a/src/main/java/com/ada/earthvalley/yomojomo/user/repositories/UserRepository.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/user/repositories/UserRepository.java
@@ -1,0 +1,11 @@
+package com.ada.earthvalley.yomojomo.user.repositories;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ada.earthvalley.yomojomo.user.entities.User;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/user/services/UserDomainService.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/user/services/UserDomainService.java
@@ -1,0 +1,31 @@
+package com.ada.earthvalley.yomojomo.user.services;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ada.earthvalley.yomojomo.auth.entities.VendorResource;
+import com.ada.earthvalley.yomojomo.auth.YomojomoOAuth2User;
+import com.ada.earthvalley.yomojomo.auth.repositories.VendorResourceRepository;
+import com.ada.earthvalley.yomojomo.user.entities.User;
+import com.ada.earthvalley.yomojomo.user.repositories.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class UserDomainService {
+	private final UserRepository userRepository;
+	private final VendorResourceRepository vendorResourceRepository;
+
+	@Transactional
+	public User createUserWithOAuth2(YomojomoOAuth2User user) {
+		User savedUser = userRepository.save(new User());
+		vendorResourceRepository.save(new VendorResource(user, savedUser));
+		return savedUser;
+	}
+
+	public User findByVendorResource(VendorResource vendorResource) {
+		return vendorResource.getUser();
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: local-postgresql, dev, jwt
+    active: local-postgresql, dev, jwt, oauth2, filters-registered
 
 ---
 # Local PostgreSQL
@@ -18,10 +18,6 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQL82Dialect
 
-jwt:
-  claims:
-    issuer: "yomojomo.com"
-  secret-key: "yomojomo-05f92a6d-eb05-451d-a102-36e6450a5e97"
 ---
 # Dev Defaults
 spring:

--- a/src/test/java/com/ada/earthvalley/yomojomo/auth/AuthTestConst.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/auth/AuthTestConst.java
@@ -1,0 +1,7 @@
+package com.ada.earthvalley.yomojomo.auth;
+
+public class AuthTestConst {
+	public static String LOGIN_URI = "/api/oauth2/login";
+	public static String SIGNUP_URI = "/api/oauth2/signup";
+	public static String DOCS_OUTPUT_DIR = "Auth/{method-name}";
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/auth/SecurityFilterChainTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/auth/SecurityFilterChainTest.java
@@ -29,8 +29,8 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import com.ada.earthvalley.yomojomo.auth.configs.WebSecurityConfig;
 import com.ada.earthvalley.yomojomo.auth.exceptions.AuthError;
 import com.ada.earthvalley.yomojomo.auth.jwt.AuthTestController;
-import com.ada.earthvalley.yomojomo.auth.jwt.JwtSecretsService;
-import com.ada.earthvalley.yomojomo.auth.jwt.JwtUtilsService;
+import com.ada.earthvalley.yomojomo.auth.jwt.services.JwtSecretsService;
+import com.ada.earthvalley.yomojomo.auth.jwt.services.JwtUtilsService;
 import com.ada.earthvalley.yomojomo.auth.jwt.dtos.YomojomoClaim;
 
 import io.jsonwebtoken.Jwts;
@@ -80,7 +80,7 @@ public class SecurityFilterChainTest {
 		Constructor<YomojomoClaim> constructor = YomojomoClaim.class.getDeclaredConstructor(UUID.class);
 		constructor.setAccessible(true);
 		YomojomoClaim yomojomoClaim = constructor.newInstance(uuid);
-		String jws = jwtUtilsService.create(yomojomoClaim);
+		String jws = jwtUtilsService.createAccessToken(yomojomoClaim);
 		assertThat(jws).isNotNull();
 
 		// when, then

--- a/src/test/java/com/ada/earthvalley/yomojomo/auth/api/OAuth2ControllerFailureTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/auth/api/OAuth2ControllerFailureTest.java
@@ -1,0 +1,49 @@
+package com.ada.earthvalley.yomojomo.auth.api;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.ada.earthvalley.yomojomo.auth.configs.OAuth2WebSecurityConfig;
+import com.ada.earthvalley.yomojomo.auth.services.OAuth2ApiService;
+
+@ContextConfiguration(
+	classes = {
+		OAuth2WebSecurityConfig.class,
+		OAuth2Controller.class
+	},
+	initializers = ConfigDataApplicationContextInitializer.class
+)
+@WebAppConfiguration
+@WebMvcTest
+public class OAuth2ControllerFailureTest {
+	@Autowired
+	private WebApplicationContext context;
+	@Autowired
+	private OAuth2Controller controller;
+	@MockBean
+	private OAuth2ApiService oAuth2ApiService;
+	private MockMvc mvc;
+
+	@BeforeEach
+	public void setup() {
+		mvc = MockMvcBuilders
+			.webAppContextSetup(context)
+			.apply(springSecurity())
+			.build();
+
+	}
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/auth/api/OAuth2ControllerRestDocs.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/auth/api/OAuth2ControllerRestDocs.java
@@ -1,0 +1,180 @@
+package com.ada.earthvalley.yomojomo.auth.api;
+
+import static com.ada.earthvalley.yomojomo.auth.AuthTestConst.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.NoSuchElementException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.ada.earthvalley.yomojomo.auth.configs.OAuth2WebSecurityConfig;
+import com.ada.earthvalley.yomojomo.auth.dtos.LoginResponse;
+import com.ada.earthvalley.yomojomo.auth.dtos.YomojomoToken;
+import com.ada.earthvalley.yomojomo.auth.services.OAuth2ApiService;
+import com.ada.earthvalley.yomojomo.configs.SpringRestDocsConfig;
+
+@DisplayName("OAuth2Controller 테스트")
+@ExtendWith(RestDocumentationExtension.class)
+@ContextConfiguration(
+	classes = {
+		OAuth2WebSecurityConfig.class,
+		OAuth2Controller.class
+	},
+	initializers = ConfigDataApplicationContextInitializer.class
+)
+@WebAppConfiguration
+@WebMvcTest(OAuth2Controller.class)
+class OAuth2ControllerRestDocs {
+	@Autowired
+	private WebApplicationContext context;
+	@Autowired
+	private OAuth2Controller controller;
+	@MockBean
+	private OAuth2ApiService oAuth2ApiService;
+	private MockMvc mvc;
+
+	@BeforeEach
+	public void setup(RestDocumentationContextProvider restDocumentation) {
+		mvc = MockMvcBuilders
+			.webAppContextSetup(context)
+			.apply(springSecurity())
+			.apply(SpringRestDocsConfig.configurer(restDocumentation))
+			.build();
+
+	}
+
+	@WithMockUser
+	@DisplayName("로그인 - 성공")
+	@Test
+	void 로그인() throws Exception {
+		// given
+		YomojomoToken accessToken = YomojomoToken.createAccessToken("access_token");
+		YomojomoToken refreshToken = YomojomoToken.createRefreshToken("refresh_token");
+		LoginResponse loginResponse = new LoginResponse(accessToken, refreshToken);
+
+		// when
+		when(oAuth2ApiService.oauth2LoginOrSignUp(null))
+			.thenReturn(loginResponse);
+
+		// then
+		mvc.perform(
+				RestDocumentationRequestBuilders
+					.get(LOGIN_URI)
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.accessToken.token", is("access_token")))
+			.andExpect(jsonPath("$.accessToken.iat").exists())
+			.andExpect(jsonPath("$.accessToken.exp").exists())
+			.andExpect(jsonPath("$.refreshToken.token", is("refresh_token")))
+			.andExpect(jsonPath("$.refreshToken.iat").exists())
+			.andExpect(jsonPath("$.refreshToken.exp").exists())
+			.andDo(document(DOCS_OUTPUT_DIR,
+				responseFields(
+					fieldWithPath("accessToken").description("JWT 인증 토큰"),
+					fieldWithPath("accessToken.token").description("토큰 값"),
+					fieldWithPath("accessToken.iat").description("토큰 발행 시점"),
+					fieldWithPath("accessToken.exp").description("토큰 만료 시점"),
+					fieldWithPath("refreshToken").description("JWT 재발급 토큰"),
+					fieldWithPath("refreshToken.token").description("토큰 값"),
+					fieldWithPath("refreshToken.iat").description("토큰 발행 시점"),
+					fieldWithPath("refreshToken.exp").description("토큰 만료 시점")
+				)
+			));
+
+		verify(oAuth2ApiService, times(1)).oauth2LoginOrSignUp(null);
+	}
+
+	@WithMockUser
+	@DisplayName("로그인 - 성공 (회원가입 endpoint 로 리다이렉트)")
+	@Test
+	void 로그인_회원가입으로_리다이렉트() throws Exception {
+		// when
+		when(oAuth2ApiService.oauth2LoginOrSignUp(null))
+			.thenThrow(NoSuchElementException.class);
+
+		// then
+		mvc.perform(
+				RestDocumentationRequestBuilders.get(LOGIN_URI)
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isFound())
+			.andExpect(header().string(HttpHeaders.LOCATION, SIGNUP_URI))
+			.andDo(document(DOCS_OUTPUT_DIR,
+				responseHeaders(
+					headerWithName(HttpHeaders.LOCATION).description("회원가입 URI")
+				)
+			));
+
+		verify(oAuth2ApiService, times(1)).oauth2LoginOrSignUp(null);
+	}
+
+	@WithMockUser
+	@DisplayName("회원가입 - 성공")
+	@Test
+	void 회원가입() throws Exception {
+		// given
+		YomojomoToken accessToken = YomojomoToken.createAccessToken("access_token");
+		YomojomoToken refreshToken = YomojomoToken.createRefreshToken("refresh_token");
+		LoginResponse loginResponse = new LoginResponse(accessToken, refreshToken);
+
+		// when
+		when(oAuth2ApiService.oauth2SignUp(null))
+			.thenReturn(loginResponse);
+
+		// then
+		mvc.perform(RestDocumentationRequestBuilders
+				.get(SIGNUP_URI)
+				.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.accessToken.token", is("access_token")))
+			.andExpect(jsonPath("$.accessToken.iat").exists())
+			.andExpect(jsonPath("$.accessToken.exp").exists())
+			.andExpect(jsonPath("$.refreshToken.token", is("refresh_token")))
+			.andExpect(jsonPath("$.refreshToken.iat").exists())
+			.andExpect(jsonPath("$.refreshToken.exp").exists())
+			.andDo(document(DOCS_OUTPUT_DIR,
+				responseFields(
+					fieldWithPath("accessToken").description("JWT 인증 토큰"),
+					fieldWithPath("accessToken.token").description("토큰 값"),
+					fieldWithPath("accessToken.iat").description("토큰 발행 시점"),
+					fieldWithPath("accessToken.exp").description("토큰 만료 시점"),
+					fieldWithPath("refreshToken").description("JWT 재발급 토큰"),
+					fieldWithPath("refreshToken.token").description("토큰 값"),
+					fieldWithPath("refreshToken.iat").description("토큰 발행 시점"),
+					fieldWithPath("refreshToken.exp").description("토큰 만료 시점")
+				)
+			));
+
+		verify(oAuth2ApiService, times(1)).oauth2SignUp(null);
+	}
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/auth/jwt/JwtUtilsServiceTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/auth/jwt/JwtUtilsServiceTest.java
@@ -18,6 +18,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.ada.earthvalley.yomojomo.auth.exceptions.YomojomoAuthException;
 import com.ada.earthvalley.yomojomo.auth.jwt.dtos.YomojomoClaim;
+import com.ada.earthvalley.yomojomo.auth.jwt.services.JwtSecretsService;
+import com.ada.earthvalley.yomojomo.auth.jwt.services.JwtUtilsService;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;

--- a/src/test/java/com/ada/earthvalley/yomojomo/auth/jwt/TokenTimeUtilsTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/auth/jwt/TokenTimeUtilsTest.java
@@ -1,0 +1,52 @@
+package com.ada.earthvalley.yomojomo.auth.jwt;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.ada.earthvalley.yomojomo.auth.jwt.services.TokenTimeUtils;
+
+@DisplayName("TokenTimeUtils 테스트")
+class TokenTimeUtilsTest {
+
+	@DisplayName("Refresh Token 시간 - 성공 (30일)")
+	@Test
+	void refresh_token_time() {
+		// when
+		Date refreshDate = TokenTimeUtils.getRefreshTokenExpiredDate();
+		LocalDateTime refreshLocalDateTime = TokenTimeUtils.getRefreshTokenLocalDateTime();
+
+		System.out.println("refreshDate = " + refreshDate);
+		System.out.println("refreshLocalDateTime = " + refreshLocalDateTime);
+
+		long refreshExpired = TimeUnit.DAYS.convert(refreshDate.getTime(), TimeUnit.MILLISECONDS);
+		long todayDate = TimeUnit.DAYS.convert(new Date().getTime(), TimeUnit.MILLISECONDS);
+
+		// then
+		assertEquals(30, refreshExpired - todayDate);
+		assertEquals(LocalDateTime.now().getDayOfMonth(), refreshLocalDateTime.minusDays(30).getDayOfMonth());
+	}
+
+	@DisplayName("Access Token 시간 - 성공 (1일)")
+	@Test
+	void access_token_time() {
+		// when
+		Date accessDate = TokenTimeUtils.getAccessTokenExpiredDate();
+		LocalDateTime accessLocalDateTime = TokenTimeUtils.getAccessTokenLocalDateTime();
+
+		System.out.println("accessDate = " + accessDate);
+		System.out.println("accessLocalDateTime = " + accessLocalDateTime);
+
+		long accessExpired = TimeUnit.DAYS.convert(accessDate.getTime(), TimeUnit.MILLISECONDS);
+		long todayDate = TimeUnit.DAYS.convert(new Date().getTime(), TimeUnit.MILLISECONDS);
+
+		// then
+		assertEquals(1, accessExpired, todayDate);
+		assertEquals(LocalDateTime.now().getDayOfMonth(), accessLocalDateTime.minusDays(1).getDayOfMonth());
+	}
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/auth/repositories/VendorResourceRepositoryTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/auth/repositories/VendorResourceRepositoryTest.java
@@ -1,0 +1,75 @@
+package com.ada.earthvalley.yomojomo.auth.repositories;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.Constructor;
+import java.util.Optional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.ada.earthvalley.yomojomo.auth.entities.VendorResource;
+import com.ada.earthvalley.yomojomo.auth.entities.enums.VendorType;
+
+@DataJpaTest
+class VendorResourceRepositoryTest {
+	@Autowired
+	VendorResourceRepository vendorResourceRepository;
+
+	@PersistenceContext
+	EntityManager em;
+
+	@BeforeEach
+	void init() {
+
+	}
+
+	@DisplayName("socialId, vendorType으로 찾기 - 실패 (없음)")
+	@Test
+	void findOptionalByVendorIdAndType_fail_empty() throws Exception {
+		// when
+		Optional<VendorResource> vendorResource = vendorResourceRepository.findByVendorIdAndType("anyString",
+			VendorType.KAKAO);
+
+		// then
+		assertThat(vendorResource).isEmpty();
+	}
+
+	@DisplayName("socialId, vendorType으로 찾기 - 성공")
+	@Test
+	void findOptionalByVendorIdAndType_success() throws Exception {
+		// given
+		final String vendorId = "123456";
+		final VendorType type = VendorType.KAKAO;
+		Constructor<VendorResource> constructor = VendorResource.class.getDeclaredConstructor();
+		constructor.setAccessible(true);
+		VendorResource vendorResource = constructor.newInstance();
+		ReflectionTestUtils.setField(vendorResource, "vendorId", vendorId);
+		ReflectionTestUtils.setField(vendorResource, "type", type);
+
+		em.persist(vendorResource);
+		flushAndClear();
+
+		// when
+		Optional<VendorResource> find = vendorResourceRepository.findByVendorIdAndType(
+			vendorId, type);
+
+		// then
+		assertThat(find).isNotEmpty();
+		assertThat(find.orElseThrow(IllegalArgumentException::new).getVendorId()).isEqualTo(vendorId);
+		assertThat(find.orElseThrow(IllegalArgumentException::new).getType()).isEqualTo(type);
+	}
+
+	void flushAndClear() {
+		em.flush();
+		em.clear();
+	}
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/auth/services/OAuth2ApiServiceTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/auth/services/OAuth2ApiServiceTest.java
@@ -1,0 +1,89 @@
+package com.ada.earthvalley.yomojomo.auth.services;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Constructor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.ada.earthvalley.yomojomo.auth.YomojomoOAuth2User;
+import com.ada.earthvalley.yomojomo.auth.dtos.LoginResponse;
+import com.ada.earthvalley.yomojomo.auth.dtos.YomojomoToken;
+import com.ada.earthvalley.yomojomo.auth.entities.VendorResource;
+import com.ada.earthvalley.yomojomo.user.entities.User;
+import com.ada.earthvalley.yomojomo.user.services.UserDomainService;
+
+@DisplayName("OAuth2ApiService 테스트")
+@ExtendWith(MockitoExtension.class)
+class OAuth2ApiServiceTest {
+	@InjectMocks
+	OAuth2ApiService oAuth2ApiService;
+	@Mock
+	VendorResourceService vendorResourceService;
+	@Mock
+	TokenDomainService tokenDomainService;
+	@Mock
+	UserDomainService userDomainService;
+
+	@DisplayName("oauth2LoginOrSignUp - 성공")
+	@Test
+	void oauth2LoginOrSignUp() throws Exception {
+		// given
+		Constructor<VendorResource> constructor = VendorResource.class.getDeclaredConstructor();
+		constructor.setAccessible(true);
+		VendorResource vendorResource = constructor.newInstance();
+		final String accessToken = "access_token_string";
+		final String refreshToken = "refresh_token_string";
+		User user = new User();
+		YomojomoToken yomojomoAccessToken = YomojomoToken.createAccessToken(accessToken);
+		YomojomoToken yomojomoRefreshToken = YomojomoToken.createRefreshToken(refreshToken);
+
+		// when
+		when(vendorResourceService.findVendorResourceOrThrow(any(YomojomoOAuth2User.class)))
+			.thenReturn(vendorResource);
+		when(userDomainService.findByVendorResource(any(VendorResource.class)))
+			.thenReturn(user);
+		when(tokenDomainService.createAccessToken(any(User.class)))
+			.thenReturn(yomojomoAccessToken);
+		when(tokenDomainService.createAndSaveRefreshToken(any(User.class)))
+			.thenReturn(yomojomoRefreshToken);
+
+		LoginResponse loginResponse = oAuth2ApiService.oauth2LoginOrSignUp(mock(YomojomoOAuth2User.class));
+
+		// then
+		assertThat(loginResponse.getAccessToken().getToken()).isEqualTo(accessToken);
+		assertThat(loginResponse.getRefreshToken().getToken()).isEqualTo(refreshToken);
+		assertThat(loginResponse.getAccessToken().getExp().isBefore(loginResponse.getRefreshToken().getExp())).isTrue();
+	}
+
+	@Test
+	void oauth2SignUp() {
+		// given
+		User user = new User();
+		final String accessToken = "access_token_string";
+		final String refreshToken = "refresh_token_string";
+		YomojomoToken yomojomoAccessToken = YomojomoToken.createAccessToken(accessToken);
+		YomojomoToken yomojomoRefreshToken = YomojomoToken.createRefreshToken(refreshToken);
+
+		// when
+		when(userDomainService.createUserWithOAuth2(any(YomojomoOAuth2User.class)))
+			.thenReturn(user);
+		when(tokenDomainService.createAccessToken(any(User.class)))
+			.thenReturn(yomojomoAccessToken);
+		when(tokenDomainService.createAndSaveRefreshToken(any(User.class)))
+			.thenReturn(yomojomoRefreshToken);
+
+		LoginResponse loginResponse = oAuth2ApiService.oauth2SignUp(mock(YomojomoOAuth2User.class));
+
+		// then
+		assertThat(loginResponse.getAccessToken().getToken()).isEqualTo(accessToken);
+		assertThat(loginResponse.getRefreshToken().getToken()).isEqualTo(refreshToken);
+		assertThat(loginResponse.getAccessToken().getExp().isBefore(loginResponse.getRefreshToken().getExp())).isTrue();
+	}
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/auth/services/TokenDomainServiceTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/auth/services/TokenDomainServiceTest.java
@@ -1,0 +1,73 @@
+package com.ada.earthvalley.yomojomo.auth.services;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.UUID;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.ada.earthvalley.yomojomo.auth.dtos.YomojomoToken;
+import com.ada.earthvalley.yomojomo.auth.jwt.dtos.YomojomoClaim;
+import com.ada.earthvalley.yomojomo.auth.jwt.services.JwtUtilsService;
+import com.ada.earthvalley.yomojomo.auth.jwt.services.TokenTimeUtils;
+import com.ada.earthvalley.yomojomo.user.entities.User;
+
+@DisplayName("TokenDomainService 테스트")
+@ExtendWith(MockitoExtension.class)
+class TokenDomainServiceTest {
+	@InjectMocks
+	TokenDomainService tokenDomainService;
+	@Mock
+	JwtUtilsService jwtUtilsService;
+
+	@DisplayName("createAccessToken - 성공")
+	@Test
+	void createAccessToken() {
+		// given
+		User user = new User();
+		ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+		final String tokenString = "access_token_string";
+
+		// when
+		when(jwtUtilsService.createAccessToken(any(YomojomoClaim.class)))
+			.thenReturn(tokenString);
+
+		YomojomoToken accessToken = tokenDomainService.createAccessToken(user);
+
+		// then
+		assertThat(accessToken).isNotNull();
+		assertThat(accessToken.getToken()).isEqualTo(tokenString);
+		assertThat(accessToken.getExp().isBefore(TokenTimeUtils.getRefreshTokenLocalDateTime()));
+	}
+
+	@DisplayName("createAndSaveRefreshToken - 성공")
+	@Test
+	void createAndSaveRefreshToken_success() {
+		// given
+		User user = new User();
+		ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+		final String tokenString = "refresh_token_string";
+
+		// when
+		when(jwtUtilsService.createRefreshToken(any(YomojomoClaim.class)))
+			.thenReturn(tokenString);
+
+		YomojomoToken refreshToken = tokenDomainService.createAndSaveRefreshToken(user);
+
+		// then
+		assertThat(refreshToken).isNotNull();
+		assertThat(refreshToken.getToken()).isEqualTo(tokenString);
+		assertThat(refreshToken.getExp().isAfter(TokenTimeUtils.getRefreshTokenLocalDateTime()));
+		assertThat(user.getRefreshToken().getRefreshToken()).isEqualTo(tokenString);
+	}
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/auth/services/VendorResourceServiceTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/auth/services/VendorResourceServiceTest.java
@@ -1,0 +1,69 @@
+package com.ada.earthvalley.yomojomo.auth.services;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.ada.earthvalley.yomojomo.auth.YomojomoOAuth2User;
+import com.ada.earthvalley.yomojomo.auth.entities.VendorResource;
+import com.ada.earthvalley.yomojomo.auth.entities.enums.VendorType;
+import com.ada.earthvalley.yomojomo.auth.repositories.VendorResourceRepository;
+
+@DisplayName("VendorResourceService 테스트")
+@ExtendWith(MockitoExtension.class)
+class VendorResourceServiceTest {
+	@InjectMocks
+	VendorResourceService vendorResourceService;
+
+	@Mock
+	VendorResourceRepository vendorResourceRepository;
+
+	@DisplayName("findVendorResourceOrThrow - 실패 (결과 없음)")
+	@Test
+	void findVendorResourceOrThrow_fail_no_result() throws Exception {
+		// given
+		OAuth2User mock = mock(OAuth2User.class);
+		YomojomoOAuth2User user = new YomojomoOAuth2User(mock);
+		ReflectionTestUtils.setField(user, "name", "123456");
+		user.setVendorType(VendorType.KAKAO);
+
+		when(vendorResourceRepository.findByVendorIdAndType(anyString(), any(VendorType.class)))
+			.thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> {
+			vendorResourceService.findVendorResourceOrThrow(user);
+		})
+			.isInstanceOf(NoSuchElementException.class);
+	}
+
+	@DisplayName("findVendorResourceOrThrow - 성공")
+	@Test
+	void findVendorResourceOrThrow_success() throws Exception {
+		// given
+		OAuth2User mock = mock(OAuth2User.class);
+		YomojomoOAuth2User user = new YomojomoOAuth2User(mock);
+		ReflectionTestUtils.setField(user, "name", "123456");
+		user.setVendorType(VendorType.KAKAO);
+
+		VendorResource vendorResource = mock(VendorResource.class);
+
+		// when
+		when(vendorResourceRepository.findByVendorIdAndType(anyString(), any(VendorType.class)))
+			.thenReturn(Optional.of(vendorResource));
+		VendorResource resultVendorResource = vendorResourceService.findVendorResourceOrThrow(user);
+
+		// then
+		assertThat(resultVendorResource).isNotNull();
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: test, h2-test-for-postgresql, jwt
+    active: test, h2-test-for-postgresql, jwt, oauth2
 
 ---
 # H2 IN MEMORY TEST PROFILE


### PR DESCRIPTION
# 작업 개요
<!-- ex) 고양이가 야옹 소리를 내도록 수정 -->
OAuth2 로그인 및 회원가입 구현

# 이슈 티켓
<!-- ex) 작업한 이슈를 태그하세요. -->
- #64 

# 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [x] 프로젝트 구조 변경
- [x] 테스트 코드 작성
- [x] 설정


# 작업 상세 내용
<!--  ex) 1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴 -->

### Access, Refresh 토큰 분리 및 TokenTimeUtils 정의
(As Is)
- JwtUtilsService는 토큰을 생성하는 메서드만 노출하고, 이에 의존하는 객체들이 상황에 따라 엑세스토큰, 재발급 토큰을 받아감.
(To Be)
- JwtUtilsService 의 공개 메서드로 access, refresh 토큰 발급하도록 변경

TokenTimeUtils를 정의해 토큰의 시간 관련한 값을 서빙하도록 리팩터링.


### TokenTimeUtils 테스트
- accessToken 만료시각과 refreshToken 만료시각 테스트

### OAuth2 시큐리티 필터 설정
OAuth2WebSecurityConfig 정의
 - "/api/oauth2/**" matcher로 적용
 - redirect 설정, authorization endpoint 설정

YomojomoOAuth2User 정의
 - Authentication의 principal로 OAuth2User를 구현한 커스텀 principal 객체를 이용
YomojomoOAuth2UserService 정의
 - OAuth2 필터체인 속에서 DefaultOAuth2User를 우리 앱의 커스텀인 YomojomoOAuth2User로 변경해주는 역할을 한다.


### OAuth2 로그인 및 회원가입 API 구현
- 로그인 API,
 - 로그인 하고자 하는 유저가 존재한다면 access token과 refresh token 발급. refresh token은 저장소에 저장
 - 해당 유저가 미가입된 상태라면 회원가입 URI로 redirect 응답을 보낸다.
- 회원가입 API
 - 빈 회원을 생성하고 해당 유저에 대해 access token과 refresh token 발급. refresh token은 저장소에 저장

### OAuth2 로그인 및 회원가입 API 테스트


# 생각해볼 문제
<!-- 1. wav 파일을 매번 입력하기 귀찮겠다. -->
계속해서 개발 외적으로 해야할게 왜이렇게 많은지...
갈수록 뇌빼고 코딩하게되네요.
이번 pr은 테스트 커버리지도 낮습니다.

