### PR TITLE
[Feat] Topic 관련 API 구현 

### DIFF
--- a/src/main/java/com/ada/earthvalley/yomojomo/article/controllers/TopicController.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/article/controllers/TopicController.java
@@ -1,0 +1,38 @@
+package com.ada.earthvalley.yomojomo.article.controllers;
+
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ada.earthvalley.yomojomo.article.dtos.SelectInterestsRequest;
+import com.ada.earthvalley.yomojomo.article.services.TopicService;
+import com.ada.earthvalley.yomojomo.auth.SecurityUser;
+import com.ada.earthvalley.yomojomo.auth.YomojomoUser;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@RestController
+public class TopicController {
+	private final TopicService topicService;
+
+	@GetMapping("/topics")
+	public ResponseEntity fetchSubtopics() {
+		return ResponseEntity.ok(topicService.fetchAllTopics());
+	}
+
+	@PostMapping("/interests")
+	public ResponseEntity selectInterests(
+		@YomojomoUser SecurityUser user,
+		@RequestBody SelectInterestsRequest body
+	) {
+		topicService.saveAllTopics(user, body);
+		return ResponseEntity.created(URI.create("/api/interests")).build();
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/article/dtos/FetchTopicsResponse.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/article/dtos/FetchTopicsResponse.java
@@ -1,0 +1,37 @@
+package com.ada.earthvalley.yomojomo.article.dtos;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.ada.earthvalley.yomojomo.article.entities.Topic;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class FetchTopicsResponse {
+	private final List<TopicResponse> topics;
+
+	@Getter
+	public static class TopicResponse {
+		private final long id;
+		private final String majorTopic;
+		private final String subTopic;
+
+		public TopicResponse(Topic topic) {
+			this.id = topic.getId();
+			this.majorTopic = topic.getMajorTopic().getValue();
+			this.subTopic = topic.getSubTopic().getValue();
+		}
+	}
+
+	public static FetchTopicsResponse ofDomain(List<Topic> topics) {
+		return new FetchTopicsResponse(
+			topics.stream()
+				.map(topic -> new TopicResponse(topic))
+				.collect(Collectors.toList()));
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/article/dtos/SelectInterestsRequest.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/article/dtos/SelectInterestsRequest.java
@@ -1,0 +1,21 @@
+package com.ada.earthvalley.yomojomo.article.dtos;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SelectInterestsRequest {
+	private List<Interests> topics;
+
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class Interests {
+		private Long id;
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/article/entities/Topic.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/article/entities/Topic.java
@@ -1,5 +1,8 @@
 package com.ada.earthvalley.yomojomo.article.entities;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -7,9 +10,12 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 
+import com.ada.earthvalley.yomojomo.article.entities.enums.MajorTopicType;
+import com.ada.earthvalley.yomojomo.article.entities.enums.SubTopicType;
 import com.ada.earthvalley.yomojomo.common.baseEntities.BaseEntity;
-import com.ada.earthvalley.yomojomo.article.entities.enums.TopicType;
+import com.ada.earthvalley.yomojomo.user.entities.UserTopic;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -25,5 +31,11 @@ public class Topic extends BaseEntity {
 	private Long id;
 
 	@Enumerated(EnumType.STRING)
-	private TopicType type;
+	private MajorTopicType majorTopic;
+
+	@Enumerated(EnumType.STRING)
+	private SubTopicType subTopic;
+
+	@OneToMany(mappedBy = "topic")
+	private List<UserTopic> userTopics = new ArrayList<>();
 }

--- a/src/main/java/com/ada/earthvalley/yomojomo/article/entities/enums/MajorTopicType.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/article/entities/enums/MajorTopicType.java
@@ -1,0 +1,15 @@
+package com.ada.earthvalley.yomojomo.article.entities.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MajorTopicType {
+	CURRENT_AFFAIR("시사"),
+	SCIENCE("과학"),
+	ECONOMY("경제"),
+	CULTURE("문화");
+
+	private final String value;
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/article/entities/enums/SubTopicType.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/article/entities/enums/SubTopicType.java
@@ -1,0 +1,35 @@
+package com.ada.earthvalley.yomojomo.article.entities.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SubTopicType {
+	// 시사
+	CURRENT_AFFAIR("시사"),
+	SOCIAl("사회"),
+	WORLD("세계"),
+	HISTORY("역사"),
+
+	// 과학
+	SCIENCE("과학"),
+	ROBOT("로봇"),
+	ENVIRONMENT("환경"),
+	HEALTH("건강"),
+	ANIMAL("동물"),
+	SPACE("우주"),
+
+	// 경제
+	ECONOMY("경제"),
+	COMPANY("회사"),
+	IT("IT"),
+
+	// 문화
+	CULTURE("문화"),
+	ARTS("예술"),
+	BROADCAST("방송"),
+	SPORTS("운동");
+
+	private final String value;
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/article/entities/enums/TopicType.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/article/entities/enums/TopicType.java
@@ -1,4 +1,0 @@
-package com.ada.earthvalley.yomojomo.article.entities.enums;
-
-public enum TopicType {
-}

--- a/src/main/java/com/ada/earthvalley/yomojomo/article/exceptions/TopicError.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/article/exceptions/TopicError.java
@@ -1,0 +1,30 @@
+package com.ada.earthvalley.yomojomo.article.exceptions;
+
+import org.springframework.http.HttpStatus;
+
+import com.ada.earthvalley.yomojomo.common.exceptions.ErrorCode;
+import com.ada.earthvalley.yomojomo.common.exceptions.ErrorInfo;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum TopicError implements ErrorInfo {
+	TOPIC_NOT_FOUND(ErrorCode.ERR3000);
+
+	private final ErrorCode code;
+
+	@Override
+	public String getMessage() {
+		return code.getMessage();
+	}
+
+	@Override
+	public int getCode() {
+		return code.getCode();
+	}
+
+	@Override
+	public HttpStatus getStatus() {
+		return code.getStatus();
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/article/exceptions/YomojomoTopicException.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/article/exceptions/YomojomoTopicException.java
@@ -1,0 +1,10 @@
+package com.ada.earthvalley.yomojomo.article.exceptions;
+
+import com.ada.earthvalley.yomojomo.common.exceptions.ErrorInfo;
+import com.ada.earthvalley.yomojomo.common.exceptions.YomojomoException;
+
+public class YomojomoTopicException extends YomojomoException {
+	public YomojomoTopicException(ErrorInfo info) {
+		super(info);
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/article/repositories/TopicRepository.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/article/repositories/TopicRepository.java
@@ -1,0 +1,10 @@
+package com.ada.earthvalley.yomojomo.article.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.ada.earthvalley.yomojomo.article.entities.Topic;
+
+@Repository
+public interface TopicRepository extends JpaRepository<Topic, Long> {
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/article/services/TopicService.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/article/services/TopicService.java
@@ -1,0 +1,45 @@
+package com.ada.earthvalley.yomojomo.article.services;
+
+import static com.ada.earthvalley.yomojomo.article.exceptions.TopicError.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ada.earthvalley.yomojomo.article.dtos.FetchTopicsResponse;
+import com.ada.earthvalley.yomojomo.article.dtos.SelectInterestsRequest;
+import com.ada.earthvalley.yomojomo.article.exceptions.YomojomoTopicException;
+import com.ada.earthvalley.yomojomo.article.repositories.TopicRepository;
+import com.ada.earthvalley.yomojomo.auth.SecurityUser;
+import com.ada.earthvalley.yomojomo.user.entities.User;
+import com.ada.earthvalley.yomojomo.user.entities.UserTopic;
+import com.ada.earthvalley.yomojomo.user.exceptions.YomojomoUserException;
+import com.ada.earthvalley.yomojomo.user.services.UserDomainService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class TopicService {
+	private final TopicRepository topicRepository;
+	private final UserDomainService userDomainService;
+
+	public FetchTopicsResponse fetchAllTopics() {
+		return FetchTopicsResponse.ofDomain(topicRepository.findAll());
+	}
+
+	@Transactional
+	public void saveAllTopics(SecurityUser securityUser, SelectInterestsRequest request) throws
+		YomojomoUserException,
+		YomojomoTopicException {
+		// TODO: 유저 존재 여부 확인은 나중에 필터 layer 로 옮김 (by Leo - 22.11.30)
+		User user = userDomainService.findByIdOrElseThrow(securityUser.getId());
+		request.getTopics()
+			.stream()
+			.map(interest -> topicRepository.findById(interest.getId())
+				.orElseThrow(() -> new YomojomoTopicException(TOPIC_NOT_FOUND)))
+			.forEach(topic -> {
+				UserTopic.create(user, topic);
+			});
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/configs/WebSecurityConfig.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/configs/WebSecurityConfig.java
@@ -29,6 +29,9 @@ public class WebSecurityConfig {
 		http
 			.addFilterAt(jwtAuthenticationFilter(), BasicAuthenticationFilter.class)
 			.antMatcher("/api/**")
+			.csrf(csrf -> {
+				csrf.disable();
+			})
 			.authorizeRequests(c -> {
 				c.anyRequest().authenticated();
 			});

--- a/src/main/java/com/ada/earthvalley/yomojomo/common/exceptions/ErrorCode.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/common/exceptions/ErrorCode.java
@@ -9,11 +9,15 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
+	// TODO: NIE 부분 삭제
 	ERR1000(1000, HttpStatus.NOT_FOUND, "NIE가 존재하지 않습니다."),
+	ERR1001(1001, HttpStatus.NOT_FOUND, "존재하지 않는 유저 입니다."),
 
 	ERR2000(2000, HttpStatus.BAD_REQUEST, "인증 헤더가 형식에 맞지 않습니다."),
 	ERR2001(2001, HttpStatus.UNAUTHORIZED, "올바르지 않은 인증 토큰입니다."),
-	ERR2002(2002, HttpStatus.UNAUTHORIZED, "인증 토큰이 만료되었습니다.");
+	ERR2002(2002, HttpStatus.UNAUTHORIZED, "인증 토큰이 만료되었습니다."),
+
+	ERR3000(3000, HttpStatus.NOT_FOUND, "존재하지 않는 토픽입니다.");
 
 	private final int code;
 	private final HttpStatus status;

--- a/src/main/java/com/ada/earthvalley/yomojomo/user/entities/UserTopic.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/user/entities/UserTopic.java
@@ -32,4 +32,13 @@ public class UserTopic extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "topic_id")
 	private Topic topic;
+
+	public static UserTopic create(User user, Topic topic) {
+		UserTopic userTopic = new UserTopic();
+		userTopic.user = user;
+		user.getUserTopics().add(userTopic);
+		userTopic.topic = topic;
+		topic.getUserTopics().add(userTopic);
+		return userTopic;
+	}
 }

--- a/src/main/java/com/ada/earthvalley/yomojomo/user/exceptions/UserError.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/user/exceptions/UserError.java
@@ -1,0 +1,32 @@
+package com.ada.earthvalley.yomojomo.user.exceptions;
+
+import static com.ada.earthvalley.yomojomo.common.exceptions.ErrorCode.*;
+
+import org.springframework.http.HttpStatus;
+
+import com.ada.earthvalley.yomojomo.common.exceptions.ErrorCode;
+import com.ada.earthvalley.yomojomo.common.exceptions.ErrorInfo;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum UserError implements ErrorInfo {
+	USER_NOT_FOUND(ERR1001)
+	;
+
+	private final ErrorCode code;
+	@Override
+	public String getMessage() {
+		return code.getMessage();
+	}
+
+	@Override
+	public int getCode() {
+		return code.getCode();
+	}
+
+	@Override
+	public HttpStatus getStatus() {
+		return code.getStatus();
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/user/exceptions/YomojomoUserException.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/user/exceptions/YomojomoUserException.java
@@ -1,0 +1,10 @@
+package com.ada.earthvalley.yomojomo.user.exceptions;
+
+import com.ada.earthvalley.yomojomo.common.exceptions.ErrorInfo;
+import com.ada.earthvalley.yomojomo.common.exceptions.YomojomoException;
+
+public class YomojomoUserException extends YomojomoException {
+	public YomojomoUserException(ErrorInfo info) {
+		super(info);
+	}
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/user/repositories/UserTopicRepository.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/user/repositories/UserTopicRepository.java
@@ -1,0 +1,8 @@
+package com.ada.earthvalley.yomojomo.user.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ada.earthvalley.yomojomo.user.entities.UserTopic;
+
+public interface UserTopicRepository extends JpaRepository<UserTopic, Long> {
+}

--- a/src/main/java/com/ada/earthvalley/yomojomo/user/services/UserDomainService.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/user/services/UserDomainService.java
@@ -1,5 +1,9 @@
 package com.ada.earthvalley.yomojomo.user.services;
 
+import static com.ada.earthvalley.yomojomo.user.exceptions.UserError.*;
+
+import java.util.UUID;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -7,6 +11,7 @@ import com.ada.earthvalley.yomojomo.auth.entities.VendorResource;
 import com.ada.earthvalley.yomojomo.auth.YomojomoOAuth2User;
 import com.ada.earthvalley.yomojomo.auth.repositories.VendorResourceRepository;
 import com.ada.earthvalley.yomojomo.user.entities.User;
+import com.ada.earthvalley.yomojomo.user.exceptions.YomojomoUserException;
 import com.ada.earthvalley.yomojomo.user.repositories.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -23,6 +28,11 @@ public class UserDomainService {
 		User savedUser = userRepository.save(new User());
 		vendorResourceRepository.save(new VendorResource(user, savedUser));
 		return savedUser;
+	}
+
+	public User findByIdOrElseThrow(UUID id) throws YomojomoUserException {
+		return userRepository.findById(id)
+			.orElseThrow(() -> new YomojomoUserException(USER_NOT_FOUND));
 	}
 
 	public User findByVendorResource(VendorResource vendorResource) {

--- a/src/test/java/com/ada/earthvalley/yomojomo/BaseIntegrationTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/BaseIntegrationTest.java
@@ -1,0 +1,52 @@
+package com.ada.earthvalley.yomojomo;
+
+import static org.assertj.core.api.Assertions.*;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ada.earthvalley.yomojomo.auth.jwt.dtos.YomojomoClaim;
+import com.ada.earthvalley.yomojomo.auth.jwt.services.JwtUtilsService;
+import com.ada.earthvalley.yomojomo.user.entities.User;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Disabled
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class BaseIntegrationTest {
+	@Autowired
+	protected MockMvc mockMvc;
+	@Autowired
+	protected EntityManager em;
+	@Autowired
+	protected ObjectMapper objectMapper;
+	@Autowired
+	protected ApplicationContext applicationContext;
+
+	protected User testUser;
+	protected String testUserAccessToken;
+
+	@BeforeEach
+	void init_test_user() {
+		testUser = new User();
+		em.persist(testUser);
+		String accessToken = applicationContext.getBean(JwtUtilsService.class)
+			.createAccessToken(YomojomoClaim.ofUser(testUser));
+		testUserAccessToken = "Bearer " + accessToken;
+		flushAndClear();
+	}
+
+	protected void flushAndClear() {
+		em.flush();
+		em.clear();
+	}
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/article/TopicConst.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/article/TopicConst.java
@@ -1,0 +1,8 @@
+package com.ada.earthvalley.yomojomo.article;
+
+public class TopicConst {
+	public static final String FETCH_ALL_URI = "/api/topics";
+	public static final String SAVE_ALL_URI = "/api/interests";
+
+	public static final String DOCS_OUTPUT_DIR = "Topic/{method-name}";
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/article/TopicFixtures.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/article/TopicFixtures.java
@@ -1,0 +1,55 @@
+package com.ada.earthvalley.yomojomo.article;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.ada.earthvalley.yomojomo.article.dtos.SelectInterestsRequest;
+import com.ada.earthvalley.yomojomo.article.dtos.SelectInterestsRequest.Interests;
+import com.ada.earthvalley.yomojomo.article.entities.Topic;
+import com.ada.earthvalley.yomojomo.article.entities.enums.MajorTopicType;
+import com.ada.earthvalley.yomojomo.article.entities.enums.SubTopicType;
+
+public class TopicFixtures {
+	public static List<Topic> topics() throws Exception {
+		List<Topic> topics = new ArrayList<>();
+		Constructor<Topic> constructor = Topic.class.getDeclaredConstructor();
+		constructor.setAccessible(true);
+		Topic topic1 = constructor.newInstance();
+		ReflectionTestUtils.setField(topic1, "id", 1L);
+		ReflectionTestUtils.setField(topic1, "majorTopic", MajorTopicType.CULTURE);
+		ReflectionTestUtils.setField(topic1, "subTopic", SubTopicType.ANIMAL);
+
+		Topic topic2 = constructor.newInstance();
+		ReflectionTestUtils.setField(topic2, "id", 2L);
+		ReflectionTestUtils.setField(topic2, "majorTopic", MajorTopicType.SCIENCE);
+		ReflectionTestUtils.setField(topic2, "subTopic", SubTopicType.IT);
+
+		Topic topic3 = constructor.newInstance();
+		ReflectionTestUtils.setField(topic3, "id", 3L);
+		ReflectionTestUtils.setField(topic3, "majorTopic", MajorTopicType.CURRENT_AFFAIR);
+		ReflectionTestUtils.setField(topic3, "subTopic", SubTopicType.BROADCAST);
+
+		Topic topic4 = constructor.newInstance();
+		ReflectionTestUtils.setField(topic4, "id", 4L);
+		ReflectionTestUtils.setField(topic4, "majorTopic", MajorTopicType.ECONOMY);
+		ReflectionTestUtils.setField(topic4, "subTopic", SubTopicType.ARTS);
+
+		topics.add(topic1);
+		topics.add(topic2);
+		topics.add(topic3);
+		topics.add(topic4);
+		return topics;
+	}
+
+	public static SelectInterestsRequest request() {
+		Interests interest1 = new Interests(1L);
+		Interests interest2 = new Interests(2L);
+		Interests interest3 = new Interests(3L);
+		Interests interest4 = new Interests(4L);
+		return new SelectInterestsRequest(
+			List.of(interest1, interest2, interest3, interest4));
+	}
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/article/api/TopicControllerFailureTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/article/api/TopicControllerFailureTest.java
@@ -1,0 +1,96 @@
+package com.ada.earthvalley.yomojomo.article.api;
+
+import static com.ada.earthvalley.yomojomo.article.TopicConst.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.ada.earthvalley.yomojomo.article.TopicFixtures;
+import com.ada.earthvalley.yomojomo.article.controllers.TopicController;
+import com.ada.earthvalley.yomojomo.article.dtos.SelectInterestsRequest;
+import com.ada.earthvalley.yomojomo.article.exceptions.TopicError;
+import com.ada.earthvalley.yomojomo.article.exceptions.YomojomoTopicException;
+import com.ada.earthvalley.yomojomo.article.services.TopicService;
+import com.ada.earthvalley.yomojomo.auth.SecurityUser;
+import com.ada.earthvalley.yomojomo.common.exceptions.handler.GlobalExceptionHandler;
+import com.ada.earthvalley.yomojomo.configs.SpringRestDocsConfig;
+import com.ada.earthvalley.yomojomo.user.exceptions.UserError;
+import com.ada.earthvalley.yomojomo.user.exceptions.YomojomoUserException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(TopicController.class)
+@ExtendWith(RestDocumentationExtension.class)
+public class TopicControllerFailureTest {
+	MockMvc mockMvc;
+	@Autowired
+	ObjectMapper objectMapper;
+	@Autowired
+	TopicController topicController;
+	@MockBean
+	TopicService topicService;
+
+	@BeforeEach
+	void init(RestDocumentationContextProvider contextProvider) {
+		mockMvc = MockMvcBuilders
+			.standaloneSetup(topicController)
+			.setControllerAdvice(GlobalExceptionHandler.class)
+			.apply(SpringRestDocsConfig.configurer(contextProvider))
+			.build();
+	}
+
+	@DisplayName("selectInterests() - 실패 (유저 없음)")
+	@Test
+	void selectInterests_fail_no_user() throws Exception {
+		// given
+		String payload = objectMapper.writeValueAsString(TopicFixtures.request());
+
+		// when
+		doThrow(new YomojomoUserException(UserError.USER_NOT_FOUND))
+			.when(topicService).saveAllTopics(any(SecurityUser.class), any(SelectInterestsRequest.class));
+
+		mockMvc.perform(
+				MockMvcRequestBuilders
+					.post(SAVE_ALL_URI)
+					.contentType(MediaType.APPLICATION_JSON_UTF8)
+					.content(payload)
+			)
+			.andDo(print())
+			.andExpect(status().isNotFound());
+
+	}
+
+	@DisplayName("selectInterests() - 실패 (토픽 없음)")
+	@Test
+	void selectInterests_fail_no_topic() throws Exception {
+		// given
+		String payload = objectMapper.writeValueAsString(TopicFixtures.request());
+
+		// when
+		doThrow(new YomojomoTopicException(TopicError.TOPIC_NOT_FOUND))
+			.when(topicService).saveAllTopics(any(SecurityUser.class), any(SelectInterestsRequest.class));
+
+		mockMvc.perform(
+				MockMvcRequestBuilders
+					.post(SAVE_ALL_URI)
+					.contentType(MediaType.APPLICATION_JSON_UTF8)
+					.content(payload)
+			)
+			.andDo(print())
+			.andExpect(status().isNotFound());
+	}
+
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/article/api/TopicControllerRestDocs.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/article/api/TopicControllerRestDocs.java
@@ -1,0 +1,122 @@
+package com.ada.earthvalley.yomojomo.article.api;
+
+import static com.ada.earthvalley.yomojomo.article.TopicConst.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.ada.earthvalley.yomojomo.article.TopicConst;
+import com.ada.earthvalley.yomojomo.article.TopicFixtures;
+import com.ada.earthvalley.yomojomo.article.controllers.TopicController;
+import com.ada.earthvalley.yomojomo.article.dtos.FetchTopicsResponse;
+import com.ada.earthvalley.yomojomo.article.dtos.SelectInterestsRequest;
+import com.ada.earthvalley.yomojomo.article.entities.Topic;
+import com.ada.earthvalley.yomojomo.article.services.TopicService;
+import com.ada.earthvalley.yomojomo.auth.SecurityUser;
+import com.ada.earthvalley.yomojomo.configs.SpringRestDocsConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(TopicController.class)
+@ExtendWith(RestDocumentationExtension.class)
+public class TopicControllerRestDocs {
+	MockMvc mockMvc;
+	@Autowired
+	ObjectMapper objectMapper;
+	@Autowired
+	TopicController topicController;
+	@MockBean
+	TopicService topicService;
+
+	@BeforeEach
+	void init(RestDocumentationContextProvider contextProvider) {
+		mockMvc = MockMvcBuilders
+			.standaloneSetup(topicController)
+			.apply(SpringRestDocsConfig.configurer(contextProvider))
+			.build();
+	}
+
+	@DisplayName("[GET] /api/topics")
+	@Test
+	void 모든_토픽_가져오기() throws Exception {
+		// given
+		List<Topic> topics = TopicFixtures.topics();
+		FetchTopicsResponse response = FetchTopicsResponse.ofDomain(topics);
+
+		// when
+		when(topicService.fetchAllTopics())
+			.thenReturn(response);
+
+		// then
+		mockMvc.perform(
+				RestDocumentationRequestBuilders
+					.get(TopicConst.FETCH_ALL_URI)
+					.contentType(MediaType.APPLICATION_JSON)
+
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.topics").exists())
+			.andExpect(jsonPath("$.topics[0].id").exists())
+			.andExpect(jsonPath("$.topics[1].majorTopic").exists())
+			.andExpect(jsonPath("$.topics[2].subTopic").exists())
+			.andDo(document(DOCS_OUTPUT_DIR,
+				// requestHeaders(
+				// 	headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
+				// ),
+				responseFields(
+					fieldWithPath("topics").description("전체 토픽"),
+					fieldWithPath("topics[].id").description("토픽의 id"),
+					fieldWithPath("topics[].majorTopic").description("토픽 대분류"),
+					fieldWithPath("topics[].subTopic").description("토픽 소분류")
+				)
+			));
+
+	}
+
+	@DisplayName("[POST] /api/interests")
+	@Test
+	void 관심있는_토픽_선택하기() throws Exception {
+		// given
+		String payload = objectMapper.writeValueAsString(TopicFixtures.request());
+
+		// when
+		doNothing()
+			.when(topicService)
+			.saveAllTopics(any(SecurityUser.class), any(SelectInterestsRequest.class));
+
+		mockMvc.perform(
+				RestDocumentationRequestBuilders
+					.post(SAVE_ALL_URI)
+					.contentType(MediaType.APPLICATION_JSON_UTF8)
+					.content(payload)
+			)
+			.andDo(print())
+			.andExpect(status().isCreated())
+			.andExpect(header().string(HttpHeaders.LOCATION, SAVE_ALL_URI))
+			.andDo(document(DOCS_OUTPUT_DIR,
+				requestFields(
+					fieldWithPath("topics").description("유저가 선택한 토픽들"),
+					fieldWithPath("topics[].id").description("토픽 id")
+				)
+			));
+	}
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/article/integration/TopicApiIntegrationTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/article/integration/TopicApiIntegrationTest.java
@@ -1,0 +1,64 @@
+package com.ada.earthvalley.yomojomo.article.integration;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import com.ada.earthvalley.yomojomo.BaseIntegrationTest;
+import com.ada.earthvalley.yomojomo.article.TopicConst;
+import com.ada.earthvalley.yomojomo.article.dtos.SelectInterestsRequest;
+import com.ada.earthvalley.yomojomo.article.dtos.SelectInterestsRequest.Interests;
+import com.ada.earthvalley.yomojomo.user.entities.User;
+
+@DisplayName("Topic API 통합 테스트 ")
+public class TopicApiIntegrationTest extends BaseIntegrationTest {
+
+	@DisplayName("모든 토픽 가져오기 - 성공")
+	@Test
+	void fetch_all_topics_success() throws Exception {
+		// when, then
+		mockMvc.perform(MockMvcRequestBuilders.get(TopicConst.FETCH_ALL_URI)
+				.header(HttpHeaders.AUTHORIZATION, testUserAccessToken)
+				.contentType(MediaType.APPLICATION_JSON_UTF8)
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.topics", hasSize(17)));
+	}
+
+	@DisplayName("토픽 선택하기 - 성공")
+	@Test
+	void select_topics_success() throws Exception {
+		// given
+		Interests interest1 = new Interests(1L);
+		Interests interest2 = new Interests(5L);
+		Interests interest3 = new Interests(15L);
+		SelectInterestsRequest request = new SelectInterestsRequest(
+			List.of(interest1, interest2, interest3));
+
+		String requestString = objectMapper.writeValueAsString(request);
+
+		// when, then
+		mockMvc.perform(MockMvcRequestBuilders.post(TopicConst.SAVE_ALL_URI)
+				.header(HttpHeaders.AUTHORIZATION, testUserAccessToken)
+				.contentType(MediaType.APPLICATION_JSON_UTF8)
+				.content(requestString)
+			)
+			.andDo(print())
+			.andExpect(status().isCreated())
+			.andExpect(header().exists(HttpHeaders.LOCATION));
+
+		// Data Test
+		User findUser = em.find(User.class, testUser.getId());
+		assertThat(findUser.getUserTopics()).hasSize(3);
+	}
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/article/repositories/TopicRepositoryTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/article/repositories/TopicRepositoryTest.java
@@ -1,0 +1,27 @@
+package com.ada.earthvalley.yomojomo.article.repositories;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import com.ada.earthvalley.yomojomo.article.entities.Topic;
+
+@DataJpaTest
+class TopicRepositoryTest {
+	@Autowired
+	TopicRepository topicRepository;
+
+	@DisplayName("findAll - 성공")
+	@Test
+	void find_all_success() {
+		// when, then
+		List<Topic> allTopics = topicRepository.findAll();
+		assertThat(allTopics).hasSize(17);
+	}
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/article/services/TopicServiceTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/article/services/TopicServiceTest.java
@@ -1,0 +1,182 @@
+package com.ada.earthvalley.yomojomo.article.services;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.ada.earthvalley.yomojomo.article.dtos.FetchTopicsResponse;
+import com.ada.earthvalley.yomojomo.article.dtos.SelectInterestsRequest;
+import com.ada.earthvalley.yomojomo.article.dtos.SelectInterestsRequest.Interests;
+import com.ada.earthvalley.yomojomo.article.entities.Topic;
+import com.ada.earthvalley.yomojomo.article.entities.enums.MajorTopicType;
+import com.ada.earthvalley.yomojomo.article.entities.enums.SubTopicType;
+import com.ada.earthvalley.yomojomo.article.exceptions.TopicError;
+import com.ada.earthvalley.yomojomo.article.exceptions.YomojomoTopicException;
+import com.ada.earthvalley.yomojomo.article.repositories.TopicRepository;
+import com.ada.earthvalley.yomojomo.auth.SecurityUser;
+import com.ada.earthvalley.yomojomo.user.entities.User;
+import com.ada.earthvalley.yomojomo.user.exceptions.UserError;
+import com.ada.earthvalley.yomojomo.user.exceptions.YomojomoUserException;
+import com.ada.earthvalley.yomojomo.user.repositories.UserRepository;
+import com.ada.earthvalley.yomojomo.user.services.UserDomainService;
+
+@DisplayName("TopicService 테스트")
+@ExtendWith(MockitoExtension.class)
+class TopicServiceTest {
+	@InjectMocks
+	TopicService topicService;
+
+	@Mock
+	TopicRepository topicRepository;
+
+	@Mock
+	UserDomainService userDomainService;
+
+	@Mock
+	SecurityUser securityUser;
+
+	List<Topic> topics = new ArrayList<>();
+
+	@BeforeEach
+	void init() throws Exception {
+		Constructor<Topic> constructor = Topic.class.getDeclaredConstructor();
+		constructor.setAccessible(true);
+		Topic topic1 = constructor.newInstance();
+		ReflectionTestUtils.setField(topic1, "id", 1L);
+		ReflectionTestUtils.setField(topic1, "majorTopic", MajorTopicType.CULTURE);
+		ReflectionTestUtils.setField(topic1, "subTopic", SubTopicType.ANIMAL);
+
+		Topic topic2 = constructor.newInstance();
+		ReflectionTestUtils.setField(topic2, "id", 2L);
+		ReflectionTestUtils.setField(topic2, "majorTopic", MajorTopicType.SCIENCE);
+		ReflectionTestUtils.setField(topic2, "subTopic", SubTopicType.IT);
+
+		Topic topic3 = constructor.newInstance();
+		ReflectionTestUtils.setField(topic3, "id", 3L);
+		ReflectionTestUtils.setField(topic3, "majorTopic", MajorTopicType.CURRENT_AFFAIR);
+		ReflectionTestUtils.setField(topic3, "subTopic", SubTopicType.BROADCAST);
+
+		Topic topic4 = constructor.newInstance();
+		ReflectionTestUtils.setField(topic4, "id", 4L);
+		ReflectionTestUtils.setField(topic4, "majorTopic", MajorTopicType.ECONOMY);
+		ReflectionTestUtils.setField(topic4, "subTopic", SubTopicType.ARTS);
+
+		topics.add(topic1);
+		topics.add(topic2);
+		topics.add(topic3);
+		topics.add(topic4);
+	}
+
+	@DisplayName("fetchAllTopics - 성공")
+	@Test
+	void fetchAllTopics_success() throws Exception {
+		// when
+		when(topicRepository.findAll())
+			.thenReturn(topics);
+
+		FetchTopicsResponse response = topicService.fetchAllTopics();
+
+		// then
+		assertThat(response.getTopics()).hasSize(4);
+		response.getTopics().forEach(topic -> {
+			assertThat(topic.getId()).isNotNull();
+			assertThat(topic.getMajorTopic()).isNotNull();
+			assertThat(topic.getSubTopic()).isNotNull();
+		});
+	}
+
+	@DisplayName("saveAllTopics - 실패 (유저 없음)")
+	@Test
+	void saveAllTopics_failure_no_user() {
+		// given
+		Interests interest1 = new Interests(1L);
+		Interests interest2 = new Interests(2L);
+		Interests interest3 = new Interests(3L);
+		Interests interest4 = new Interests(4L);
+		SelectInterestsRequest request = new SelectInterestsRequest(
+			List.of(interest1, interest2, interest3, interest4));
+
+		// when
+		when(securityUser.getId())
+			.thenReturn(UUID.randomUUID());
+		when(userDomainService.findByIdOrElseThrow(any(UUID.class)))
+			.thenThrow(new YomojomoUserException(UserError.USER_NOT_FOUND));
+
+		// then
+		assertThatThrownBy(() -> {
+			topicService.saveAllTopics(securityUser, request);
+		})
+			.isInstanceOf(YomojomoUserException.class);
+	}
+
+	@DisplayName("saveAllTopics - 실패 (토픽 없음)")
+	@Test
+	void saveAllTopics_failure_no_topic() {
+		// given
+		Interests interest1 = new Interests(1L);
+		Interests interest2 = new Interests(2L);
+		Interests interest3 = new Interests(3L);
+		Interests interest4 = new Interests(4L);
+		SelectInterestsRequest request = new SelectInterestsRequest(
+			List.of(interest1, interest2, interest3, interest4));
+
+		// when
+		when(securityUser.getId())
+			.thenReturn(UUID.randomUUID());
+		when(userDomainService.findByIdOrElseThrow(any(UUID.class)))
+			.thenReturn(new User());
+		when(topicRepository.findById(anyLong()))
+			.thenThrow(new YomojomoTopicException(TopicError.TOPIC_NOT_FOUND));
+
+		// then
+		assertThatThrownBy(() -> {
+			topicService.saveAllTopics(securityUser, request);
+		})
+			.isInstanceOf(YomojomoTopicException.class);
+	}
+
+	@DisplayName("saveAllTopics - 성공")
+	@Test
+	void saveAllTopics_success() {
+		// given
+		User user = new User();
+		Interests interest1 = new Interests(1L);
+		Interests interest2 = new Interests(2L);
+		Interests interest3 = new Interests(3L);
+		Interests interest4 = new Interests(4L);
+		SelectInterestsRequest request = new SelectInterestsRequest(
+			List.of(interest1, interest2, interest3, interest4));
+
+		// when
+		when(securityUser.getId())
+			.thenReturn(UUID.randomUUID());
+		when(userDomainService.findByIdOrElseThrow(any(UUID.class)))
+			.thenReturn(user);
+		when(topicRepository.findById(anyLong()))
+			.thenReturn(Optional.of(topics.get(0)))
+			.thenReturn(Optional.of(topics.get(1)))
+			.thenReturn(Optional.of(topics.get(2)))
+			.thenReturn(Optional.of(topics.get(3)));
+
+		// then
+		topicService.saveAllTopics(securityUser, request);
+		assertThat(user.getUserTopics()).hasSize(4);
+
+		verify(topicRepository, times(4)).findById(anyLong());
+	}
+}

--- a/src/test/java/com/ada/earthvalley/yomojomo/user/services/UserDomainServiceTest.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/user/services/UserDomainServiceTest.java
@@ -1,0 +1,60 @@
+package com.ada.earthvalley.yomojomo.user.services;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.ada.earthvalley.yomojomo.user.entities.User;
+import com.ada.earthvalley.yomojomo.user.exceptions.YomojomoUserException;
+import com.ada.earthvalley.yomojomo.user.repositories.UserRepository;
+
+@DisplayName("UserDomainService 테스트")
+@ExtendWith(MockitoExtension.class)
+class UserDomainServiceTest {
+	@InjectMocks
+	UserDomainService userDomainService;
+
+	@Mock
+	UserRepository userRepository;
+
+	@DisplayName("findByIdOrElseThrow - 실패 (유저 없음)")
+	@Test
+	void findByIdOrElseThrow_failure_no_user() {
+		// when
+		when(userRepository.findById(any(UUID.class)))
+			.thenReturn(Optional.empty());
+
+		// then
+		assertThatThrownBy(() -> {
+			userDomainService.findByIdOrElseThrow(UUID.randomUUID());
+		})
+			.isInstanceOf(YomojomoUserException.class);
+	}
+
+	@DisplayName("findByIdOrElseThrow - 성공")
+	@Test
+	void findByIdOrElseThrow_success() {
+		// given
+		User user = new User();
+
+		// when
+		when(userRepository.findById(any(UUID.class)))
+			.thenReturn(Optional.of(user));
+
+		User byId = userDomainService.findByIdOrElseThrow(UUID.randomUUID());
+
+		// then
+		assertThat(byId).isNotNull();
+	}
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -16,6 +16,7 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
+    defer-datasource-initialization: true
 
 ---
 # TEST DEFAULTS

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,0 +1,24 @@
+-- 시사
+INSERT INTO topic (topic_id, major_topic, sub_topic) VALUES (1, 'CURRENT_AFFAIR', 'CURRENT_AFFAIR');
+INSERT INTO topic (topic_id, major_topic, sub_topic) VALUES (2, 'CURRENT_AFFAIR', 'SOCIAl');
+INSERT INTO topic (topic_id, major_topic, sub_topic) VALUES (3, 'CURRENT_AFFAIR', 'WORLD');
+INSERT INTO topic (topic_id, major_topic, sub_topic) VALUES (4, 'CURRENT_AFFAIR', 'HISTORY');
+
+-- 과학
+INSERT INTO topic (topic_id, major_topic, sub_topic) VALUES (5, 'SCIENCE', 'SCIENCE');
+INSERT INTO topic (topic_id, major_topic, sub_topic) VALUES (6, 'SCIENCE', 'ROBOT');
+INSERT INTO topic (topic_id, major_topic, sub_topic) VALUES (7, 'SCIENCE', 'ENVIRONMENT');
+INSERT INTO topic (topic_id, major_topic, sub_topic) VALUES (8, 'SCIENCE', 'HEALTH');
+INSERT INTO topic (topic_id, major_topic, sub_topic) VALUES (9, 'SCIENCE', 'ANIMAL');
+INSERT INTO topic (topic_id, major_topic, sub_topic) VALUES (10, 'SCIENCE', 'SPACE');
+
+-- 경제
+INSERT INTO topic (topic_id, major_topic, sub_topic) VALUES (11, 'ECONOMY', 'ECONOMY');
+INSERT INTO topic (topic_id, major_topic, sub_topic) VALUES (12, 'ECONOMY', 'COMPANY');
+INSERT INTO topic (topic_id, major_topic, sub_topic) VALUES (13, 'ECONOMY', 'IT');
+
+-- 문화
+INSERT INTO topic (topic_id, major_topic, sub_topic) VALUES (14, 'CULTURE', 'CULTURE');
+INSERT INTO topic (topic_id, major_topic, sub_topic) VALUES (15, 'CULTURE', 'ARTS');
+INSERT INTO topic (topic_id, major_topic, sub_topic) VALUES (16, 'CULTURE', 'BROADCAST');
+INSERT INTO topic (topic_id, major_topic, sub_topic) VALUES (17, 'CULTURE', 'SPORTS');


### PR DESCRIPTION
# 작업 개요
<!-- ex) 고양이가 야옹 소리를 내도록 수정 -->
GET 토픽 불러오기 API
POST 토픽 설정하기 API 

# 이슈 티켓
<!-- ex) 작업한 이슈를 태그하세요. -->
- #68 


# 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [x] 프로젝트 구조 변경
- [x] 테스트 코드 작성
- [ ] 설정


# 작업 상세 내용
<!--  ex) 1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴 -->  3. 

### Topic 관련 Entity Layer의 변경사항
- Topic은 이제 대분류, 소분류로 구분된다. (MajorTopicType, SubTopicType)
- 기존의 TopicType 삭제
- UserTopic의 생성 편의 메서드 추가
- UserTopicRepository, TopicRepository 추가

### Topic 관련 Repository Layer 테스트
- 디폴트 토픽을 생성하는 data.sql 정의
- test path의 application.yml에 Hibernate가 .sql 스크립트보다 먼저 실행되도록 defer-datasource-initialization 추가

TopicRepositoryTest
- 모든 토픽 찾기 (성공)

### Topic 관련 Service Layer
- TopicService 구현
  - 모든 토픽 가져오기
  - 선택한 토픽 유저에게 저장하기
- UserDomainService.findByIdOrElseThrow 구현
- TopicError, YomojomoTopicException 정의
- UserError, YomojomoUserException 정의

### Topic 관련 Service Layer 테스트
- TopicConst에 Test에 이용되는 상수 정의
- TopicFixtures 정의

TopicServiceTest
- 모든 토픽 가져오기
  - 성공
- 선택한 토픽 저장하기
  - 성공
  - 실패
    - (case1) 유저 없음
    - (case2) 토픽 없음

UserDomainServiceTest
- 유저 불러오기
  - 성공
  - 실패 (유저 없음)

### Topic 관련 Web Layer 구현
- Jwt 시큐리티 필터체인의 csrf 설정 off
- TopicController 정의
- request, response 정의

### Topic 관련 Web Layer 및 Integration 테스트 진행
TopicControllerTest
- 모든 토픽 가져오기
  - 성공
- 토픽 선택하기
  - 성공
  - 실패
    - (case1) 유저 없음
    - (case2) 토픽 없음

TopicApiIntegrationTest
- 모든 토픽 가져오기
- 토픽 선택하기

### 통합 테스트를 위한 base class 정의 
- BaseIntegrationTest
  - 기본 테스트 유저 정의


# 생각해볼 문제
<!-- 1. wav 파일을 매번 입력하기 귀찮겠다. -->
바쁘다 바빠 


