### PR TITLE
[Fix]인증 관련 api path 변경

### DIFF
--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/api/OAuth2Controller.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/api/OAuth2Controller.java
@@ -9,15 +9,15 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.ada.earthvalley.yomojomo.auth.dtos.LoginResponse;
 import com.ada.earthvalley.yomojomo.auth.YomojomoOAuth2User;
 import com.ada.earthvalley.yomojomo.auth.YomojomoUser;
+import com.ada.earthvalley.yomojomo.auth.dtos.LoginResponse;
 import com.ada.earthvalley.yomojomo.auth.services.OAuth2ApiService;
 
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/oauth2")
+@RequestMapping("/oauth2")
 @RestController
 public class OAuth2Controller {
 	private final OAuth2ApiService authApiService;
@@ -27,7 +27,7 @@ public class OAuth2Controller {
 		try {
 			return ResponseEntity.ok(authApiService.oauth2LoginOrSignUp(user));
 		} catch (NoSuchElementException e) {
-			return ResponseEntity.status(HttpStatus.FOUND).header(HttpHeaders.LOCATION, "/api/oauth2/signup").build();
+			return ResponseEntity.status(HttpStatus.FOUND).header(HttpHeaders.LOCATION, "/oauth2/signup").build();
 		}
 	}
 

--- a/src/main/java/com/ada/earthvalley/yomojomo/auth/configs/OAuth2WebSecurityConfig.java
+++ b/src/main/java/com/ada/earthvalley/yomojomo/auth/configs/OAuth2WebSecurityConfig.java
@@ -13,11 +13,11 @@ public class OAuth2WebSecurityConfig {
 	@Bean
 	public SecurityFilterChain oauth2SecurityFilterChain(HttpSecurity http) throws Exception {
 		http
-			.antMatcher("/api/oauth2/**")
+			.antMatcher("/oauth2/**")
 			.oauth2Login(oauth2 -> {
 				oauth2
 					.authorizationEndpoint(authorization -> {
-						authorization.baseUri("/api/oauth2/authorization");
+						authorization.baseUri("/oauth2/authorization");
 					})
 					.userInfoEndpoint(userInfo -> {
 						userInfo.userService(new YomojomoOAuth2UserService());

--- a/src/test/java/com/ada/earthvalley/yomojomo/auth/AuthTestConst.java
+++ b/src/test/java/com/ada/earthvalley/yomojomo/auth/AuthTestConst.java
@@ -1,7 +1,7 @@
 package com.ada.earthvalley.yomojomo.auth;
 
 public class AuthTestConst {
-	public static String LOGIN_URI = "/api/oauth2/login";
-	public static String SIGNUP_URI = "/api/oauth2/signup";
+	public static String LOGIN_URI = "/oauth2/login";
+	public static String SIGNUP_URI = "/oauth2/signup";
 	public static String DOCS_OUTPUT_DIR = "Auth/{method-name}";
 }


### PR DESCRIPTION
## 작업 개요
<!-- ex) 고양이가 야옹 소리를 내도록 수정 -->
로컬에서 잘 작동하던 코드가 EC2에 올리니 antMatchers가 필터를 잘못 등록했다. 


## 이슈 티켓
<!-- ex) 작업한 이슈를 태그하세요. -->
#83 

## 작업 분류
- [X] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ] 설정


## 작업 상세 내용
<!--  ex) 1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴 -->
기존 api들의 path는 "/api"로 시작했다. 로그인 관련 api도 마찬가지였다. 그리고 로그인 api의 경우는 "/api/oauth"의 경로를 가졌다. 
Filerchain 등록하는 부분에 "/api/oauth"의 코드를 사용하면 다른 필터를 등록하도록 했다. 하지만 왜인지 기존의 filter들을 등록 했다. 

아직 정확하게 원인은 모르나 예측해보건데 "/api"의 부분이 겹쳐 둘 다 기존의 filter를 등록한건가 싶다.... 

## 생각해볼 문제
<!-- 1. wav 파일을 매번 입력하기 귀찮겠다. -->
왜 로컬에서는 잘 돌아갔는데 서버에서 안된걸까...?


